### PR TITLE
7 fix xml tests

### DIFF
--- a/src/evaluateUpdatingExpression.ts
+++ b/src/evaluateUpdatingExpression.ts
@@ -26,6 +26,7 @@ export type UpdatingOptions = {
 	namespaceResolver?: (s: string) => string | null;
 	nodesFactory?: INodesFactory;
 	returnType?: ReturnType;
+	annotateAst?: boolean;
 };
 
 /**
@@ -65,6 +66,7 @@ export default async function evaluateUpdatingExpression(
 				allowXQuery: true,
 				debug: !!options['debug'],
 				disableCache: !!options['disableCache'],
+				annotateAst: !!options['annotateAst'],
 			}
 		);
 		dynamicContext = context.dynamicContext;

--- a/src/evaluateUpdatingExpression.ts
+++ b/src/evaluateUpdatingExpression.ts
@@ -18,6 +18,7 @@ import { Language, Logger } from './types/Options';
  * @public
  */
 export type UpdatingOptions = {
+	annotateAst?: boolean;
 	debug?: boolean;
 	disableCache?: boolean;
 	documentWriter?: IDocumentWriter;
@@ -26,7 +27,6 @@ export type UpdatingOptions = {
 	namespaceResolver?: (s: string) => string | null;
 	nodesFactory?: INodesFactory;
 	returnType?: ReturnType;
-	annotateAst?: boolean;
 };
 
 /**

--- a/src/evaluateUpdatingExpression.ts
+++ b/src/evaluateUpdatingExpression.ts
@@ -50,7 +50,10 @@ export default async function evaluateUpdatingExpression(
 	options?: UpdatingOptions | null
 ): Promise<{ pendingUpdateList: object[]; xdmValue: any[] }> {
 	options = options || {
-		annotateAst: true,
+		/* TODO: This could probably be changed. Setting this to true makes a single test fail in `alltests`
+		 *		 but this test does not fail when running the tests separately.
+		 */
+		annotateAst: false,
 	};
 
 	let dynamicContext: DynamicContext;

--- a/src/evaluateUpdatingExpression.ts
+++ b/src/evaluateUpdatingExpression.ts
@@ -49,7 +49,9 @@ export default async function evaluateUpdatingExpression(
 	variables?: { [s: string]: any } | null,
 	options?: UpdatingOptions | null
 ): Promise<{ pendingUpdateList: object[]; xdmValue: any[] }> {
-	options = options || {};
+	options = options || {
+		annotateAst: true,
+	};
 
 	let dynamicContext: DynamicContext;
 	let executionParameters: ExecutionParameters;

--- a/src/evaluateUpdatingExpressionSync.ts
+++ b/src/evaluateUpdatingExpressionSync.ts
@@ -54,6 +54,7 @@ export default function evaluateUpdatingExpressionSync<
 				allowXQuery: true,
 				debug: !!options['debug'],
 				disableCache: !!options['disableCache'],
+				annotateAst: !!options['annotateAst'],
 			}
 		);
 		dynamicContext = context.dynamicContext;

--- a/src/evaluateUpdatingExpressionSync.ts
+++ b/src/evaluateUpdatingExpressionSync.ts
@@ -37,7 +37,9 @@ export default function evaluateUpdatingExpressionSync<
 	variables?: { [s: string]: any } | null,
 	options?: UpdatingOptions | null
 ): { pendingUpdateList: object[]; xdmValue: IReturnTypes<TNode>[TReturnType] } {
-	options = options || {};
+	options = options || {
+		annotateAst: true,
+	};
 
 	let dynamicContext: DynamicContext;
 	let executionParameters: ExecutionParameters;

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -155,6 +155,7 @@ const evaluateXPath = <TNode extends Node, TReturnType extends keyof IReturnType
 					options['language'] === Language.XQUERY_UPDATE_3_1_LANGUAGE,
 				debug: !!options['debug'],
 				disableCache: !!options['disableCache'],
+				annotateAst: !!options['annotateAst'],
 			}
 		);
 		dynamicContext = context.dynamicContext;

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -136,7 +136,9 @@ const evaluateXPath = <TNode extends Node, TReturnType extends keyof IReturnType
 		throw new TypeError("Failed to execute 'evaluateXPath': xpathExpression must be a string.");
 	}
 
-	options = options || {};
+	options = options || {
+		annotateAst: true,
+	};
 
 	let dynamicContext: DynamicContext;
 	let executionParameters: ExecutionParameters;

--- a/src/evaluationUtils/buildEvaluationContext.ts
+++ b/src/evaluationUtils/buildEvaluationContext.ts
@@ -100,8 +100,8 @@ export default function buildEvaluationContext(
 		};
 	} else {
 		internalOptions = {
-			// tslint:disable-next-line:no-console
 			annotateAst: true,
+			// tslint:disable-next-line:no-console
 			logger: { trace: console.log.bind(console) },
 			moduleImports: {},
 			namespaceResolver: null,

--- a/src/evaluationUtils/buildEvaluationContext.ts
+++ b/src/evaluationUtils/buildEvaluationContext.ts
@@ -89,6 +89,7 @@ export default function buildEvaluationContext(
 	let internalOptions: Options;
 	if (externalOptions) {
 		internalOptions = {
+			annotateAst: true,
 			// tslint:disable-next-line:no-console
 			logger: externalOptions['logger'] || { trace: console.log.bind(console) },
 			documentWriter: externalOptions['documentWriter'],
@@ -100,6 +101,7 @@ export default function buildEvaluationContext(
 	} else {
 		internalOptions = {
 			// tslint:disable-next-line:no-console
+			annotateAst: true,
 			logger: { trace: console.log.bind(console) },
 			moduleImports: {},
 			namespaceResolver: null,

--- a/src/evaluationUtils/buildEvaluationContext.ts
+++ b/src/evaluationUtils/buildEvaluationContext.ts
@@ -76,6 +76,7 @@ export default function buildEvaluationContext(
 		allowXQuery: boolean;
 		debug: boolean;
 		disableCache: boolean;
+		annotateAst: boolean;
 	}
 ): {
 	dynamicContext: DynamicContext;

--- a/src/evaluationUtils/buildEvaluationContext.ts
+++ b/src/evaluationUtils/buildEvaluationContext.ts
@@ -74,9 +74,9 @@ export default function buildEvaluationContext(
 	compilationOptions: {
 		allowUpdating: boolean;
 		allowXQuery: boolean;
+		annotateAst: boolean;
 		debug: boolean;
 		disableCache: boolean;
-		annotateAst: boolean;
 	}
 ): {
 	dynamicContext: DynamicContext;

--- a/src/expressions/functions/builtInFunctions_fontoxpath.ts
+++ b/src/expressions/functions/builtInFunctions_fontoxpath.ts
@@ -55,14 +55,11 @@ const fontoxpathEvaluate: FunctionDefinitionType = (
 				);
 				const innerStaticContext = new StaticContext(executionSpecificStaticContext);
 
-				const ast = parseExpression(
-					queryString,
-					{
-						allowXQuery: false,
-						debug: executionParameters.debug,
-					},
-					true
-				);
+				const ast = parseExpression(queryString, {
+					allowXQuery: false,
+					debug: executionParameters.debug,
+					annotateAst: true,
+				});
 
 				const prolog = astHelper.followPath(ast, ['mainModule', 'prolog']);
 				if (prolog) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ function parseXPath(xpathString: string) {
 		return cachedExpression;
 	}
 
-	const ast = parseExpression(xpathString, { allowXQuery: false }, true);
+	const ast = parseExpression(xpathString, { allowXQuery: false, annotateAst: false });
 
 	const queryBody = astHelper.followPath(ast, ['mainModule', 'queryBody', '*']);
 

--- a/src/parseScript.ts
+++ b/src/parseScript.ts
@@ -158,14 +158,11 @@ export default function parseScript<TElement extends Element>(
 	simpleNodesFactory: ISimpleNodesFactory,
 	documentWriter: IDocumentWriter = domBackedDocumentWriter
 ): TElement {
-	const ast = parseExpression(
-		script,
-		{
-			allowXQuery: options['language'] === Language.XQUERY_UPDATE_3_1_LANGUAGE,
-			debug: options.debug,
-		},
-		false
-	);
+	const ast = parseExpression(script, {
+		allowXQuery: options['language'] === Language.XQUERY_UPDATE_3_1_LANGUAGE,
+		debug: options.debug,
+		annotateAst: options.annotateAst,
+	});
 
 	return parseNode(documentWriter, simpleNodesFactory, ast, null) as TElement;
 }

--- a/src/parsing/parseExpression.ts
+++ b/src/parsing/parseExpression.ts
@@ -20,8 +20,7 @@ function getParseResultFromCache(input: string, language: string) {
  */
 export default function parseExpression(
 	xPathString: string,
-	compilationOptions: { allowXQuery?: boolean; debug?: boolean },
-	shouldAnnotateAst: boolean = false
+	compilationOptions: { allowXQuery?: boolean; debug?: boolean; annotateAst?: boolean }
 ): IAST {
 	const language = compilationOptions.allowXQuery ? 'XQuery' : 'XPath';
 	const cached = compilationOptions.debug ? null : getParseResultFromCache(xPathString, language);
@@ -40,7 +39,7 @@ export default function parseExpression(
 			}
 		}
 
-		if (shouldAnnotateAst) {
+		if (compilationOptions.annotateAst) {
 			annotateAst(ast);
 		}
 

--- a/src/parsing/parseExpression.ts
+++ b/src/parsing/parseExpression.ts
@@ -20,7 +20,7 @@ function getParseResultFromCache(input: string, language: string) {
  */
 export default function parseExpression(
 	xPathString: string,
-	compilationOptions: { allowXQuery?: boolean; debug?: boolean; annotateAst?: boolean }
+	compilationOptions: { allowXQuery?: boolean; annotateAst?: boolean; debug?: boolean }
 ): IAST {
 	const language = compilationOptions.allowXQuery ? 'XQuery' : 'XPath';
 	const cached = compilationOptions.debug ? null : getParseResultFromCache(xPathString, language);

--- a/src/parsing/staticallyCompileXPath.ts
+++ b/src/parsing/staticallyCompileXPath.ts
@@ -19,6 +19,7 @@ export default function staticallyCompileXPath(
 		allowXQuery: boolean | undefined;
 		debug: boolean | undefined;
 		disableCache: boolean | undefined;
+		annotateAst: boolean | undefined;
 	},
 	namespaceResolver: (namespace: string) => string | null,
 	variables: object,
@@ -55,7 +56,7 @@ export default function staticallyCompileXPath(
 		expression = fromCache.expression;
 	} else {
 		// We can not use anything from the cache, parse + compile
-		const ast = parseExpression(xpathString, compilationOptions, true);
+		const ast = parseExpression(xpathString, compilationOptions);
 
 		const mainModule = astHelper.getFirstChild(ast, 'mainModule');
 		if (!mainModule) {

--- a/src/parsing/staticallyCompileXPath.ts
+++ b/src/parsing/staticallyCompileXPath.ts
@@ -17,9 +17,9 @@ export default function staticallyCompileXPath(
 	compilationOptions: {
 		allowUpdating: boolean | undefined;
 		allowXQuery: boolean | undefined;
+		annotateAst: boolean | undefined;
 		debug: boolean | undefined;
 		disableCache: boolean | undefined;
-		annotateAst: boolean | undefined;
 	},
 	namespaceResolver: (namespace: string) => string | null,
 	variables: object,

--- a/src/registerXQueryModule.ts
+++ b/src/registerXQueryModule.ts
@@ -19,14 +19,11 @@ export default function registerXQueryModule(
 	moduleString: string,
 	options: { debug: boolean } = { debug: false }
 ): string {
-	const parsedModule = parseExpression(
-		moduleString,
-		{
-			allowXQuery: true,
-			debug: options['debug'],
-		},
-		true
-	);
+	const parsedModule = parseExpression(moduleString, {
+		allowXQuery: true,
+		debug: options['debug'],
+		annotateAst: true,
+	});
 
 	const libraryModule = astHelper.getFirstChild(parsedModule, 'libraryModule');
 	if (!libraryModule) {

--- a/src/typeInference/annotateBinaryOperator.ts
+++ b/src/typeInference/annotateBinaryOperator.ts
@@ -31,7 +31,7 @@ export function annotateAddOp(
 		isSubtypeOf(right.type, ValueType.XSNUMERIC)
 	) {
 		const type = {
-			type: BINOP_LOOKUP[left.type + right.type * 1000] ?? ValueType.XSDECIMAL,
+			type: BINOP_LOOKUP[left.type + right.type * 1000] || ValueType.XSDECIMAL,
 			mult: left.mult,
 		};
 		ast.push(['type', type]);

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -61,6 +61,12 @@ export type NamespaceResolver = (prefix: string) => string | null;
  */
 export type Options = {
 	/**
+	 * Whether or not the AST should get annotated after parsing an expression. The annotation adds
+	 * additional type information to the AST.
+	 */
+	annotateAst?: boolean;
+
+	/**
 	 * The current context for a query. Will be passed whenever an extension function is called. Can be
 	 * used to implement the current function in XSLT.
 	 *
@@ -151,6 +157,4 @@ export type Options = {
 	 * elements using the document implementation related to the passed context node.
 	 */
 	nodesFactory?: INodesFactory;
-
-	annotateAst?: boolean;
 };

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -151,4 +151,6 @@ export type Options = {
 	 * elements using the document implementation related to the passed context node.
 	 */
 	nodesFactory?: INodesFactory;
+
+	annotateAst?: boolean;
 };

--- a/test/xQueryXUtils.ts
+++ b/test/xQueryXUtils.ts
@@ -39,7 +39,7 @@ export function buildTestCase(
 		try {
 			astElement = parseScript(
 				xQuery,
-				{ language: Language.XQUERY_UPDATE_3_1_LANGUAGE },
+				{ annotateAst: false, language: Language.XQUERY_UPDATE_3_1_LANGUAGE },
 				new slimdom.Document()
 			);
 		} catch (err) {
@@ -85,10 +85,16 @@ export function buildTestCase(
 		}
 
 		if (
-			!evaluateXPathToBoolean('deep-equal($expected, $actual)', null, null, {
-				expected,
-				actual,
-			})
+			!evaluateXPathToBoolean(
+				'deep-equal($expected, $actual)',
+				null,
+				null,
+				{
+					expected,
+					actual,
+				},
+				{ annotateAst: false }
+			)
 		) {
 			try {
 				chai.assert.equal(

--- a/test/xqutsTests.ts
+++ b/test/xqutsTests.ts
@@ -30,6 +30,7 @@ type ExpressionArguments = [
 	any,
 	Object,
 	{
+		annotateAst?: boolean;
 		debug?: boolean;
 		returnType?: any;
 		language?: EvaluateXPath['XPATH_3_1_LANGUAGE'] | EvaluateXPath['XQUERY_3_1_LANGUAGE'];


### PR DESCRIPTION
# Description

This pull requests fixes the failing XML tests by adding a flag to conditionally disable the AST annotation.

Closes #7 

# Changes

1. Add `annotateAst` flag to parseExpression
2. This flag has been propagated through the rest of the codebase

# Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

# How Many Approvals?

* 1 Approval (Small bugs/hot-fixes)