### PR TITLE
Substract opp annotation

### DIFF
--- a/src/evaluateUpdatingExpression.ts
+++ b/src/evaluateUpdatingExpression.ts
@@ -26,6 +26,7 @@ export type UpdatingOptions = {
 	namespaceResolver?: (s: string) => string | null;
 	nodesFactory?: INodesFactory;
 	returnType?: ReturnType;
+	annotateAst?: boolean;
 };
 
 /**
@@ -65,6 +66,7 @@ export default async function evaluateUpdatingExpression(
 				allowXQuery: true,
 				debug: !!options['debug'],
 				disableCache: !!options['disableCache'],
+				annotateAst: !!options['annotateAst'],
 			}
 		);
 		dynamicContext = context.dynamicContext;

--- a/src/evaluateUpdatingExpression.ts
+++ b/src/evaluateUpdatingExpression.ts
@@ -18,6 +18,7 @@ import { Language, Logger } from './types/Options';
  * @public
  */
 export type UpdatingOptions = {
+	annotateAst?: boolean;
 	debug?: boolean;
 	disableCache?: boolean;
 	documentWriter?: IDocumentWriter;
@@ -26,7 +27,6 @@ export type UpdatingOptions = {
 	namespaceResolver?: (s: string) => string | null;
 	nodesFactory?: INodesFactory;
 	returnType?: ReturnType;
-	annotateAst?: boolean;
 };
 
 /**

--- a/src/evaluateUpdatingExpressionSync.ts
+++ b/src/evaluateUpdatingExpressionSync.ts
@@ -54,6 +54,7 @@ export default function evaluateUpdatingExpressionSync<
 				allowXQuery: true,
 				debug: !!options['debug'],
 				disableCache: !!options['disableCache'],
+				annotateAst: !!options['annotateAst'],
 			}
 		);
 		dynamicContext = context.dynamicContext;

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -155,6 +155,7 @@ const evaluateXPath = <TNode extends Node, TReturnType extends keyof IReturnType
 					options['language'] === Language.XQUERY_UPDATE_3_1_LANGUAGE,
 				debug: !!options['debug'],
 				disableCache: !!options['disableCache'],
+				annotateAst: !!options['annotateAst'],
 			}
 		);
 		dynamicContext = context.dynamicContext;

--- a/src/evaluationUtils/buildEvaluationContext.ts
+++ b/src/evaluationUtils/buildEvaluationContext.ts
@@ -76,6 +76,7 @@ export default function buildEvaluationContext(
 		allowXQuery: boolean;
 		debug: boolean;
 		disableCache: boolean;
+		annotateAst: boolean;
 	}
 ): {
 	dynamicContext: DynamicContext;

--- a/src/evaluationUtils/buildEvaluationContext.ts
+++ b/src/evaluationUtils/buildEvaluationContext.ts
@@ -74,9 +74,9 @@ export default function buildEvaluationContext(
 	compilationOptions: {
 		allowUpdating: boolean;
 		allowXQuery: boolean;
+		annotateAst: boolean;
 		debug: boolean;
 		disableCache: boolean;
-		annotateAst: boolean;
 	}
 ): {
 	dynamicContext: DynamicContext;

--- a/src/expressions/functions/builtInFunctions_fontoxpath.ts
+++ b/src/expressions/functions/builtInFunctions_fontoxpath.ts
@@ -55,14 +55,11 @@ const fontoxpathEvaluate: FunctionDefinitionType = (
 				);
 				const innerStaticContext = new StaticContext(executionSpecificStaticContext);
 
-				const ast = parseExpression(
-					queryString,
-					{
-						allowXQuery: false,
-						debug: executionParameters.debug,
-					},
-					true
-				);
+				const ast = parseExpression(queryString, {
+					allowXQuery: false,
+					debug: executionParameters.debug,
+					annotateAst: true,
+				});
 
 				const prolog = astHelper.followPath(ast, ['mainModule', 'prolog']);
 				if (prolog) {

--- a/src/expressions/operators/arithmetic/BinaryOperator.ts
+++ b/src/expressions/operators/arithmetic/BinaryOperator.ts
@@ -73,7 +73,7 @@ function generateBinaryOperatorFunction(
 			const { castA, castB } = applyCastFunctions(a, b);
 
 			return createAtomicValue(castA.value - castB.value, retType.type);
-		}
+		};
 	}
 
 	if (isSubtypeOf(typeA, ValueType.XSNUMERIC) && isSubtypeOf(typeB, ValueType.XSNUMERIC)) {

--- a/src/expressions/operators/arithmetic/BinaryOperator.ts
+++ b/src/expressions/operators/arithmetic/BinaryOperator.ts
@@ -69,6 +69,12 @@ function generateBinaryOperatorFunction(
 
 			return createAtomicValue(castA.value + castB.value, retType.type);
 		};
+	} else if (operator === 'substractOp' && retType) {
+		return (a, b) => {
+			const { castA, castB } = applyCastFunctions(a, b);
+
+			return createAtomicValue(castA.value - castB.value, retType.type);
+		}
 	}
 
 	if (isSubtypeOf(typeA, ValueType.XSNUMERIC) && isSubtypeOf(typeB, ValueType.XSNUMERIC)) {

--- a/src/expressions/operators/arithmetic/BinaryOperator.ts
+++ b/src/expressions/operators/arithmetic/BinaryOperator.ts
@@ -62,14 +62,13 @@ function generateBinaryOperatorFunction(
 			castB: castFunctionForValueB ? castFunctionForValueB(valueB) : valueB,
 		};
 	}
-
 	if (operator === 'addOp' && retType) {
 		return (a, b) => {
 			const { castA, castB } = applyCastFunctions(a, b);
 
 			return createAtomicValue(castA.value + castB.value, retType.type);
 		};
-	} else if (operator === 'substractOp' && retType) {
+	} else if (operator === 'subtractOp' && retType) {
 		return (a, b) => {
 			const { castA, castB } = applyCastFunctions(a, b);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ function parseXPath(xpathString: string) {
 		return cachedExpression;
 	}
 
-	const ast = parseExpression(xpathString, { allowXQuery: false }, true);
+	const ast = parseExpression(xpathString, { allowXQuery: false, annotateAst: false });
 
 	const queryBody = astHelper.followPath(ast, ['mainModule', 'queryBody', '*']);
 

--- a/src/parseScript.ts
+++ b/src/parseScript.ts
@@ -158,14 +158,11 @@ export default function parseScript<TElement extends Element>(
 	simpleNodesFactory: ISimpleNodesFactory,
 	documentWriter: IDocumentWriter = domBackedDocumentWriter
 ): TElement {
-	const ast = parseExpression(
-		script,
-		{
-			allowXQuery: options['language'] === Language.XQUERY_UPDATE_3_1_LANGUAGE,
-			debug: options.debug,
-		},
-		false
-	);
+	const ast = parseExpression(script, {
+		allowXQuery: options['language'] === Language.XQUERY_UPDATE_3_1_LANGUAGE,
+		debug: options.debug,
+		annotateAst: options.annotateAst,
+	});
 
 	return parseNode(documentWriter, simpleNodesFactory, ast, null) as TElement;
 }

--- a/src/parsing/parseExpression.ts
+++ b/src/parsing/parseExpression.ts
@@ -20,8 +20,7 @@ function getParseResultFromCache(input: string, language: string) {
  */
 export default function parseExpression(
 	xPathString: string,
-	compilationOptions: { allowXQuery?: boolean; debug?: boolean },
-	shouldAnnotateAst: boolean = false
+	compilationOptions: { allowXQuery?: boolean; debug?: boolean; annotateAst?: boolean }
 ): IAST {
 	const language = compilationOptions.allowXQuery ? 'XQuery' : 'XPath';
 	const cached = compilationOptions.debug ? null : getParseResultFromCache(xPathString, language);
@@ -40,7 +39,7 @@ export default function parseExpression(
 			}
 		}
 
-		if (shouldAnnotateAst) {
+		if (compilationOptions.annotateAst) {
 			annotateAst(ast);
 		}
 

--- a/src/parsing/parseExpression.ts
+++ b/src/parsing/parseExpression.ts
@@ -20,7 +20,7 @@ function getParseResultFromCache(input: string, language: string) {
  */
 export default function parseExpression(
 	xPathString: string,
-	compilationOptions: { allowXQuery?: boolean; debug?: boolean; annotateAst?: boolean }
+	compilationOptions: { allowXQuery?: boolean; annotateAst?: boolean; debug?: boolean }
 ): IAST {
 	const language = compilationOptions.allowXQuery ? 'XQuery' : 'XPath';
 	const cached = compilationOptions.debug ? null : getParseResultFromCache(xPathString, language);

--- a/src/parsing/staticallyCompileXPath.ts
+++ b/src/parsing/staticallyCompileXPath.ts
@@ -19,6 +19,7 @@ export default function staticallyCompileXPath(
 		allowXQuery: boolean | undefined;
 		debug: boolean | undefined;
 		disableCache: boolean | undefined;
+		annotateAst: boolean | undefined;
 	},
 	namespaceResolver: (namespace: string) => string | null,
 	variables: object,
@@ -55,7 +56,7 @@ export default function staticallyCompileXPath(
 		expression = fromCache.expression;
 	} else {
 		// We can not use anything from the cache, parse + compile
-		const ast = parseExpression(xpathString, compilationOptions, true);
+		const ast = parseExpression(xpathString, compilationOptions);
 
 		const mainModule = astHelper.getFirstChild(ast, 'mainModule');
 		if (!mainModule) {

--- a/src/parsing/staticallyCompileXPath.ts
+++ b/src/parsing/staticallyCompileXPath.ts
@@ -17,9 +17,9 @@ export default function staticallyCompileXPath(
 	compilationOptions: {
 		allowUpdating: boolean | undefined;
 		allowXQuery: boolean | undefined;
+		annotateAst: boolean | undefined;
 		debug: boolean | undefined;
 		disableCache: boolean | undefined;
-		annotateAst: boolean | undefined;
 	},
 	namespaceResolver: (namespace: string) => string | null,
 	variables: object,

--- a/src/registerXQueryModule.ts
+++ b/src/registerXQueryModule.ts
@@ -19,14 +19,11 @@ export default function registerXQueryModule(
 	moduleString: string,
 	options: { debug: boolean } = { debug: false }
 ): string {
-	const parsedModule = parseExpression(
-		moduleString,
-		{
-			allowXQuery: true,
-			debug: options['debug'],
-		},
-		true
-	);
+	const parsedModule = parseExpression(moduleString, {
+		allowXQuery: true,
+		debug: options['debug'],
+		annotateAst: true,
+	});
 
 	const libraryModule = astHelper.getFirstChild(parsedModule, 'libraryModule');
 	if (!libraryModule) {

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -47,7 +47,7 @@ export function annotate(ast: IAST): SequenceType | undefined {
 
 			return annotateAddOp(ast, left, right);
 		}
-		case 'substractOpp': {
+		case 'subtractOp': {
 			const left = annotate(ast[1][1] as IAST);
 			const right = annotate(ast[2][1] as IAST);
 

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -41,14 +41,18 @@ export function annotate(ast: IAST): SequenceType | undefined {
 	switch (ast[0]) {
 		case 'unaryMinusOp':
 			return annotateUnaryMinusOp(ast);
-		case 'addOp':
+		case 'addOp': {
 			const left = annotate(ast[1][1] as IAST);
 			const right = annotate(ast[2][1] as IAST);
 
 			return annotateAddOp(ast, left, right);
-		case 'substractOpp':
+		}
+		case 'substractOpp': {
+			const left = annotate(ast[1][1] as IAST);
+			const right = annotate(ast[2][1] as IAST);
 
 			return annotateSubstractOpp(ast, left, right);
+		}
 		case 'integerConstantExpr':
 			ast.push([
 				'type',

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -1,6 +1,6 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import { IAST } from '../parsing/astHelper';
-import { annotateAddOp } from './annotateBinaryOperator';
+import { annotateAddOp, annotateSubstractOpp } from './annotateBinaryOperator';
 
 export default function annotateAst(ast: IAST): SequenceType | undefined {
 	const type = annotateUpperLevel(ast);
@@ -46,6 +46,9 @@ export function annotate(ast: IAST): SequenceType | undefined {
 			const right = annotate(ast[2][1] as IAST);
 
 			return annotateAddOp(ast, left, right);
+		case 'substractOpp':
+
+			return annotateSubstractOpp(ast, left, right);
 		case 'integerConstantExpr':
 			ast.push([
 				'type',

--- a/src/typeInference/annotateBinaryOperator.ts
+++ b/src/typeInference/annotateBinaryOperator.ts
@@ -114,3 +114,21 @@ export function annotateAddOp(
 
 	return undefined;
 }
+
+export function annotateSubstractOpp(
+	ast: IAST,
+	left: SequenceType | undefined,
+	right: SequenceType | undefined
+) {
+	if (
+		(isSubtypeOf(left.type, ValueType.XSDATETIME) &&
+			isSubtypeOf(right.type, ValueType.XSDATETIME)) ||
+		(isSubtypeOf(left.type, ValueType.XSDATE) && isSubtypeOf(right.type, ValueType.XSDATE)) ||
+		(isSubtypeOf(left.type, ValueType.XSTIME) && isSubtypeOf(right.type, ValueType.XSTIME))
+	) {
+		ast.push(['type', { type: ValueType.XSDAYTIMEDURATION, mult: left.mult }]);
+		return { type: ValueType.XSDAYTIMEDURATION, mult: left.mult };
+	} else {
+		annotateAddOp(ast, left, right);
+	}
+}

--- a/src/typeInference/annotateBinaryOperator.ts
+++ b/src/typeInference/annotateBinaryOperator.ts
@@ -129,6 +129,6 @@ export function annotateSubstractOpp(
 		ast.push(['type', { type: ValueType.XSDAYTIMEDURATION, mult: left.mult }]);
 		return { type: ValueType.XSDAYTIMEDURATION, mult: left.mult };
 	} else {
-		annotateAddOp(ast, left, right);
+		return annotateAddOp(ast, left, right);
 	}
 }

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -151,4 +151,6 @@ export type Options = {
 	 * elements using the document implementation related to the passed context node.
 	 */
 	nodesFactory?: INodesFactory;
+
+	annotateAst?: boolean;
 };

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -60,6 +60,8 @@ export type NamespaceResolver = (prefix: string) => string | null;
  * @public
  */
 export type Options = {
+	annotateAst?: boolean;
+
 	/**
 	 * The current context for a query. Will be passed whenever an extension function is called. Can be
 	 * used to implement the current function in XSLT.
@@ -151,6 +153,4 @@ export type Options = {
 	 * elements using the document implementation related to the passed context node.
 	 */
 	nodesFactory?: INodesFactory;
-
-	annotateAst?: boolean;
 };


### PR DESCRIPTION
# Pull Request

## Description

Added the ability to annotate the substractOperation and added the shortcut in binaryOperator

closes `#15`

## Changes

1. added annotation in annotateBinary
2. added the shortcut

## Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

## How Many Approvals?

* 2 Approvals (Normal features and bugs)