### PR TITLE
Unary Operator Annotation

### DIFF
--- a/src/expressions/operators/arithmetic/Unary.ts
+++ b/src/expressions/operators/arithmetic/Unary.ts
@@ -6,6 +6,31 @@ import sequenceFactory from '../../dataTypes/sequenceFactory';
 import { SequenceMultiplicity, ValueType } from '../../dataTypes/Value';
 import Expression from '../../Expression';
 
+type UnaryLookupTable = {
+	[key: number]: ValueType;
+};
+
+// TODO: fix this?
+const UNARY_LOOKUP: UnaryLookupTable = {
+	[ValueType.XSINTEGER]: ValueType.XSINTEGER,
+	[ValueType.XSNONPOSITIVEINTEGER]: ValueType.XSINTEGER,
+	[ValueType.XSNEGATIVEINTEGER]: ValueType.XSINTEGER,
+	[ValueType.XSLONG]: ValueType.XSINTEGER,
+	[ValueType.XSINT]: ValueType.XSINTEGER,
+	[ValueType.XSSHORT]: ValueType.XSINTEGER,
+	[ValueType.XSBYTE]: ValueType.XSINTEGER,
+	[ValueType.XSNONNEGATIVEINTEGER]: ValueType.XSINTEGER,
+	[ValueType.XSUNSIGNEDLONG]: ValueType.XSINTEGER,
+	[ValueType.XSUNSIGNEDINT]: ValueType.XSINTEGER,
+	[ValueType.XSUNSIGNEDSHORT]: ValueType.XSINTEGER,
+	[ValueType.XSUNSIGNEDBYTE]: ValueType.XSINTEGER,
+	[ValueType.XSPOSITIVEINTEGER]: ValueType.XSINTEGER,
+
+	[ValueType.XSDECIMAL]: ValueType.XSDECIMAL,
+	[ValueType.XSFLOAT]: ValueType.XSFLOAT,
+	[ValueType.XSDOUBLE]: ValueType.XSDOUBLE,
+};
+
 class Unary extends Expression {
 	private _kind: string;
 	private _valueExpr: Expression;
@@ -50,40 +75,49 @@ class Unary extends Expression {
 				);
 			}
 
-			if (this._kind === '+') {
-				if (
-					isSubtypeOf(value.type, ValueType.XSDECIMAL) ||
-					isSubtypeOf(value.type, ValueType.XSDOUBLE) ||
-					isSubtypeOf(value.type, ValueType.XSFLOAT) ||
-					isSubtypeOf(value.type, ValueType.XSINTEGER)
-				) {
+			const isNumeric = isSubtypeOf(value.type, ValueType.XSNUMERIC);
+
+			if (isNumeric) {
+				if (this._kind === '+') {
 					return sequenceFactory.singleton(atomizedValues[0]);
 				}
-				return sequenceFactory.singleton(createAtomicValue(Number.NaN, ValueType.XSDOUBLE));
-			}
-
-			if (isSubtypeOf(value.type, ValueType.XSINTEGER)) {
 				return sequenceFactory.singleton(
-					createAtomicValue((value.value as number) * -1, ValueType.XSINTEGER)
+					createAtomicValue((value.value as number) * -1, value.type)
 				);
 			}
-			if (isSubtypeOf(value.type, ValueType.XSDECIMAL)) {
-				return sequenceFactory.singleton(
-					createAtomicValue((value.value as number) * -1, ValueType.XSDECIMAL)
-				);
-			}
-			if (isSubtypeOf(value.type, ValueType.XSDOUBLE)) {
-				return sequenceFactory.singleton(
-					createAtomicValue((value.value as number) * -1, ValueType.XSDOUBLE)
-				);
-			}
-			if (isSubtypeOf(value.type, ValueType.XSFLOAT)) {
-				return sequenceFactory.singleton(
-					createAtomicValue((value.value as number) * -1, ValueType.XSFLOAT)
-				);
-			}
-
 			return sequenceFactory.singleton(createAtomicValue(Number.NaN, ValueType.XSDOUBLE));
+
+			// if (this._kind === '+') {
+			// 	if (
+			// 		isSubtypeOf(value.type, ValueType.XSNUMERIC)
+			// 	) {
+			// 		return sequenceFactory.singleton(atomizedValues[0]);
+			// 	}
+			// 	return sequenceFactory.singleton(createAtomicValue(Number.NaN, ValueType.XSDOUBLE));
+			// }
+
+			// if (isSubtypeOf(value.type, ValueType.XSINTEGER)) {
+			// 	return sequenceFactory.singleton(
+			// 		createAtomicValue((value.value as number) * -1, ValueType.XSINTEGER)
+			// 	);
+			// }
+			// if (isSubtypeOf(value.type, ValueType.XSDECIMAL)) {
+			// 	return sequenceFactory.singleton(
+			// 		createAtomicValue((value.value as number) * -1, ValueType.XSDECIMAL)
+			// 	);
+			// }
+			// if (isSubtypeOf(value.type, ValueType.XSDOUBLE)) {
+			// 	return sequenceFactory.singleton(
+			// 		createAtomicValue((value.value as number) * -1, ValueType.XSDOUBLE)
+			// 	);
+			// }
+			// if (isSubtypeOf(value.type, ValueType.XSFLOAT)) {
+			// 	return sequenceFactory.singleton(
+			// 		createAtomicValue((value.value as number) * -1, ValueType.XSFLOAT)
+			// 	);
+			// }
+
+			// return sequenceFactory.singleton(createAtomicValue(Number.NaN, ValueType.XSDOUBLE));
 		});
 	}
 }

--- a/src/expressions/operators/arithmetic/Unary.ts
+++ b/src/expressions/operators/arithmetic/Unary.ts
@@ -3,7 +3,7 @@ import castToType from '../../dataTypes/castToType';
 import createAtomicValue from '../../dataTypes/createAtomicValue';
 import isSubtypeOf from '../../dataTypes/isSubtypeOf';
 import sequenceFactory from '../../dataTypes/sequenceFactory';
-import { SequenceMultiplicity, ValueType } from '../../dataTypes/Value';
+import { SequenceMultiplicity, SequenceType, ValueType } from '../../dataTypes/Value';
 import Expression from '../../Expression';
 
 type UnaryLookupTable = {
@@ -40,10 +40,9 @@ class Unary extends Expression {
 	 * @param  kind       Either + or -
 	 * @param  valueExpr  The selector evaluating to the value to process
 	 */
-	constructor(kind: string, valueExpr: Expression) {
-		super(valueExpr.specificity, [valueExpr], { canBeStaticallyEvaluated: false });
+	constructor(kind: string, valueExpr: Expression, type: SequenceType) {
+		super(valueExpr.specificity, [valueExpr], { canBeStaticallyEvaluated: false }, false, type);
 		this._valueExpr = valueExpr;
-
 		this._kind = kind;
 	}
 

--- a/src/expressions/operators/arithmetic/Unary.ts
+++ b/src/expressions/operators/arithmetic/Unary.ts
@@ -82,42 +82,10 @@ class Unary extends Expression {
 					return sequenceFactory.singleton(atomizedValues[0]);
 				}
 				return sequenceFactory.singleton(
-					createAtomicValue((value.value as number) * -1, value.type)
+					createAtomicValue((value.value as number) * -1, UNARY_LOOKUP[value.type])
 				);
 			}
 			return sequenceFactory.singleton(createAtomicValue(Number.NaN, ValueType.XSDOUBLE));
-
-			// if (this._kind === '+') {
-			// 	if (
-			// 		isSubtypeOf(value.type, ValueType.XSNUMERIC)
-			// 	) {
-			// 		return sequenceFactory.singleton(atomizedValues[0]);
-			// 	}
-			// 	return sequenceFactory.singleton(createAtomicValue(Number.NaN, ValueType.XSDOUBLE));
-			// }
-
-			// if (isSubtypeOf(value.type, ValueType.XSINTEGER)) {
-			// 	return sequenceFactory.singleton(
-			// 		createAtomicValue((value.value as number) * -1, ValueType.XSINTEGER)
-			// 	);
-			// }
-			// if (isSubtypeOf(value.type, ValueType.XSDECIMAL)) {
-			// 	return sequenceFactory.singleton(
-			// 		createAtomicValue((value.value as number) * -1, ValueType.XSDECIMAL)
-			// 	);
-			// }
-			// if (isSubtypeOf(value.type, ValueType.XSDOUBLE)) {
-			// 	return sequenceFactory.singleton(
-			// 		createAtomicValue((value.value as number) * -1, ValueType.XSDOUBLE)
-			// 	);
-			// }
-			// if (isSubtypeOf(value.type, ValueType.XSFLOAT)) {
-			// 	return sequenceFactory.singleton(
-			// 		createAtomicValue((value.value as number) * -1, ValueType.XSFLOAT)
-			// 	);
-			// }
-
-			// return sequenceFactory.singleton(createAtomicValue(Number.NaN, ValueType.XSDOUBLE));
 		});
 	}
 }

--- a/src/expressions/operators/arithmetic/Unary.ts
+++ b/src/expressions/operators/arithmetic/Unary.ts
@@ -3,7 +3,7 @@ import castToType from '../../dataTypes/castToType';
 import createAtomicValue from '../../dataTypes/createAtomicValue';
 import isSubtypeOf from '../../dataTypes/isSubtypeOf';
 import sequenceFactory from '../../dataTypes/sequenceFactory';
-import { SequenceMultiplicity, SequenceType, ValueType } from '../../dataTypes/Value';
+import { SequenceType, ValueType } from '../../dataTypes/Value';
 import Expression from '../../Expression';
 
 type UnaryLookupTable = {

--- a/src/expressions/operators/arithmetic/Unary.ts
+++ b/src/expressions/operators/arithmetic/Unary.ts
@@ -64,6 +64,15 @@ class Unary extends Expression {
 
 			const value = atomizedValues[0];
 
+			if (this.type) {
+				return sequenceFactory.singleton(
+					createAtomicValue(
+						this._kind === '+' ? value.value : -value.value,
+						UNARY_LOOKUP[value.type]
+					)
+				);
+			}
+
 			if (isSubtypeOf(value.type, ValueType.XSUNTYPEDATOMIC)) {
 				const castValue = castToType(value, ValueType.XSDOUBLE).value as number;
 				return sequenceFactory.singleton(
@@ -74,11 +83,9 @@ class Unary extends Expression {
 				);
 			}
 
-			const isNumeric = isSubtypeOf(value.type, ValueType.XSNUMERIC);
-
-			if (isNumeric) {
+			if (isSubtypeOf(value.type, ValueType.XSNUMERIC)) {
 				if (this._kind === '+') {
-					return sequenceFactory.singleton(atomizedValues[0]);
+					return sequenceFactory.singleton(value);
 				}
 				return sequenceFactory.singleton(
 					createAtomicValue((value.value as number) * -1, UNARY_LOOKUP[value.type])

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -1031,7 +1031,12 @@ function unaryPlus(
 	compilationOptions: { allowUpdating?: boolean; allowXQuery?: boolean }
 ) {
 	const operand = astHelper.getFirstChild(astHelper.getFirstChild(ast, 'operand'), '*');
-	return new Unary('+', compile(operand, compilationOptions));
+	const typeNode = astHelper.followPath(ast, ['type']);
+	return new Unary(
+		'+',
+		compile(operand, compilationOptions),
+		typeNode ? (typeNode[1] as SequenceType) : undefined
+	);
 }
 
 function unaryMinus(
@@ -1039,7 +1044,12 @@ function unaryMinus(
 	compilationOptions: { allowUpdating?: boolean; allowXQuery?: boolean }
 ) {
 	const operand = astHelper.getFirstChild(astHelper.getFirstChild(ast, 'operand'), '*');
-	return new Unary('-', compile(operand, compilationOptions));
+	const typeNode = astHelper.followPath(ast, ['type']);
+	return new Unary(
+		'-',
+		compile(operand, compilationOptions),
+		typeNode ? (typeNode[1] as SequenceType) : undefined
+	);
 }
 
 function unionOp(ast: IAST, compilationOptions: CompilationOptions) {

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -1,6 +1,7 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import { IAST } from '../parsing/astHelper';
 import { annotateAddOp } from './annotateBinaryOperator';
+import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
 
 export default function annotateAst(ast: IAST): SequenceType | undefined {
 	const type = annotateUpperLevel(ast);
@@ -28,19 +29,19 @@ function annotateUpperLevel(ast: IAST): SequenceType | undefined {
 	}
 }
 
-function annotateUnaryMinusOp(ast: IAST): SequenceType | undefined {
-	const child = annotate(ast[1][1]);
-
-	if (!child) return undefined;
-
-	ast.push(['type', child]);
-	return child;
-}
-
+/**
+ * Annotates a given node within the AST.
+ * @param ast Node of the query's AST.
+ * @returns Sequence type corresponding to said node.
+ */
 export function annotate(ast: IAST): SequenceType | undefined {
 	switch (ast[0]) {
 		case 'unaryMinusOp':
-			return annotateUnaryMinusOp(ast);
+			const minVal = annotate(ast[1][1] as IAST);
+			return annotateUnaryMinus(ast, minVal);
+		case 'unaryPlusOp':
+			const plusVal = annotate(ast[1][1] as IAST);
+			return annotateUnaryPlus(ast, plusVal);
 		case 'addOp':
 			const left = annotate(ast[1][1] as IAST);
 			const right = annotate(ast[2][1] as IAST);

--- a/src/typeInference/annotateUnaryOperator.ts
+++ b/src/typeInference/annotateUnaryOperator.ts
@@ -26,8 +26,6 @@ export function annotateUnaryMinus(
 		return type;
 	}
 
-	// TODO: This path does not mean it's invalid per se,
-	// documentation states that especially plus is used for casting to a number.
 	return undefined;
 }
 
@@ -55,6 +53,5 @@ export function annotateUnaryPlus(
 		return type;
 	}
 
-	// TODO: This path does not mean it's invalid per se,
 	return undefined;
 }

--- a/src/typeInference/annotateUnaryOperator.ts
+++ b/src/typeInference/annotateUnaryOperator.ts
@@ -1,0 +1,60 @@
+import isSubtypeOf from '../expressions/dataTypes/isSubtypeOf';
+import { SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import { IAST } from '../parsing/astHelper';
+
+/**
+ * Adds the unary minus operator type annotation to the AST
+ * The unary minus returns the value of its operand with the sign negated (-2 = -2 and --2 = 2)
+ * @param ast A reference to the AST, so a new node can be inserted
+ * @param valueType The type of the value that the operator is called on.
+ * @returns An appropriate SequenceType if the operation was valid, undefined if not.
+ */
+export function annotateUnaryMinus(
+	ast: IAST,
+	valueType: SequenceType | undefined
+): SequenceType | undefined {
+	if (!valueType) {
+		return undefined;
+	}
+
+	if (isSubtypeOf(valueType.type, ValueType.XSNUMERIC)) {
+		const type = {
+			type: valueType.type,
+			mult: valueType.mult,
+		};
+		ast.push(['type', type]);
+		return type;
+	}
+
+	// TODO: This path does not mean it's invalid per se,
+	// documentation states that especially plus is used for casting to a number.
+	return undefined;
+}
+
+/**
+ * Adds the unary plus operator type annotation to the AST.
+ * The unary plus returns the value of its operand with the sign unchanged (+2 = 2 and +-2 = -2)
+ * @param ast A reference to the AST, so a new node can be inserted
+ * @param valueType The type of the value that the operator is called on.
+ * @returns An appropriate SequenceType if the operation was valid, undefined if not.
+ */
+export function annotateUnaryPlus(
+	ast: IAST,
+	valueType: SequenceType | undefined
+): SequenceType | undefined {
+	if (!valueType) {
+		return undefined;
+	}
+
+	if (isSubtypeOf(valueType.type, ValueType.XSNUMERIC)) {
+		const type = {
+			type: valueType.type,
+			mult: valueType.mult,
+		};
+		ast.push(['type', type]);
+		return type;
+	}
+
+	// TODO: This path does not mean it's invalid per se,
+	return undefined;
+}


### PR DESCRIPTION
### Description

Adds optional type annotation support for the unary operators, while keeping the dynamic code intact as a fallback in case there is no possible type deduction.

Closes #9 

### Changes

1. Annotation support was added for the unary + and - operators
2. The Unary expression class was cleaned up
3. Typed unary is returned now from `compileAstToExpression`

### Side-Effects/Affected Domains

AST Annotation
Unary-related classes

### Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

### How many approvals?

* 3 Approvals (Bigger features that span multiple domains/releases to master)