### PR TITLE
Cleanup annotateAst

### DIFF
--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -3,29 +3,8 @@ import { IAST } from '../parsing/astHelper';
 import { annotateAddOp } from './annotateBinaryOperator';
 
 export default function annotateAst(ast: IAST): SequenceType | undefined {
-	const type = annotateUpperLevel(ast);
+	const type = annotate(ast);
 	return type;
-}
-
-function annotateUpperLevel(ast: IAST): SequenceType | undefined {
-	if (!ast) return undefined;
-
-	switch (ast[0]) {
-		case 'module':
-			return annotateUpperLevel(ast[1] as IAST);
-		case 'libraryModule':
-			return annotateUpperLevel(ast[2] as IAST);
-		case 'mainModule':
-			return annotateUpperLevel(ast[1] as IAST);
-		case 'queryModule':
-			return annotateUpperLevel(ast[1] as IAST);
-		case 'queryBody':
-			return annotate(ast[1] as IAST);
-		case 'prolog':
-			return annotateUpperLevel(ast[1] as IAST);
-		case 'functionDecl':
-			return annotateUpperLevel(ast[3] as IAST);
-	}
 }
 
 function annotateUnaryMinusOp(ast: IAST): SequenceType | undefined {
@@ -38,6 +17,10 @@ function annotateUnaryMinusOp(ast: IAST): SequenceType | undefined {
 }
 
 export function annotate(ast: IAST): SequenceType | undefined {
+	if (!ast) {
+		return undefined;
+	}
+
 	switch (ast[0]) {
 		case 'unaryMinusOp':
 			return annotateUnaryMinusOp(ast);
@@ -77,6 +60,9 @@ export function annotate(ast: IAST): SequenceType | undefined {
 			]);
 			return { type: ValueType.XSSTRING, mult: SequenceMultiplicity.EXACTLY_ONE };
 		default:
+			for (let i = 1; i < ast.length; i++) {
+				annotate(ast[i] as IAST);
+			}
 			return { type: ValueType.XSERROR, mult: SequenceMultiplicity.EXACTLY_ONE };
 	}
 }


### PR DESCRIPTION
# Description

With this merge request, all unknown nodes get traversed as well. This makes sure all supported nodes in the whole AST get annotated. It also cleans up annotateAst.ts a bit.

Closes #17 

# Changes

1. remove annotateUpperLevel
2. add 'generic' annotation for unknown nodes

# Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.


# How Many Approvals?

* 2 Approvals (Normal features and bugs)