### PR TITLE
Make the bundlemon step optional

### DIFF
--- a/.github/workflows/bundlesize.yml
+++ b/.github/workflows/bundlesize.yml
@@ -23,6 +23,7 @@ jobs:
               run: echo "CI_COMMIT_SHA=${{ github.event.pull_request.head.sha}}" >> $GITHUB_ENV
 
             - name: Run BundleMon
+              if: secrets.BUNDLEMON_PROJECT_APIKEY
               run: npx bundlemon
               env:
                 BUNDLEMON_PROJECT_ID: "609024effb87a20009a6b096"


### PR DESCRIPTION
## Description

This fixed the wrong setup of the Bundlemon. Now it won't fail the pipeline anymore!

Closes #21 

## Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

## How Many Approvals?

* 1 Approval (Small bugs/hot-fixes)