### PR TITLE
30 Added Integer Division to the Binary Operator Annotation

### DIFF
--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -23,6 +23,7 @@ export function annotate(ast: IAST): SequenceType | undefined {
 			return annotateUnaryPlus(ast, plusVal);
 		case 'addOp':
 		case 'divOp':
+		case 'idivOp':
 			const left = annotate(ast[1][1] as IAST);
 			const right = annotate(ast[2][1] as IAST);
 

--- a/src/typeInference/annotateBinaryOperator.ts
+++ b/src/typeInference/annotateBinaryOperator.ts
@@ -184,7 +184,7 @@ const BINOP_EVAL_FUNCTIONS: EvalFuncTable = {
 		(l: number, r: number) => Math.trunc(l / r),
 		ValueType.XSINTEGER,
 	],
-	
+
 	// Integer Division, double over integer
 	[hash(ValueType.XSDOUBLE, ValueType.XSINTEGER, 'idiv')]: [
 		(l: number, r: number) => Math.trunc(l / r),
@@ -195,7 +195,7 @@ const BINOP_EVAL_FUNCTIONS: EvalFuncTable = {
 		(l: number, r: number) => Math.trunc(l / r),
 		ValueType.XSINTEGER,
 	],
-	
+
 	// Integer Division, decimal over integer
 	[hash(ValueType.XSDECIMAL, ValueType.XSINTEGER, 'idiv')]: [
 		(l: number, r: number) => Math.trunc(l / r),
@@ -206,14 +206,14 @@ const BINOP_EVAL_FUNCTIONS: EvalFuncTable = {
 		(l: number, r: number) => Math.trunc(l / r),
 		ValueType.XSINTEGER,
 	],
-	
+
 	// Integer Division, numeric over integer
 	[hash(ValueType.XSNUMERIC, ValueType.XSINTEGER, 'idiv')]: [
 		(l: number, r: number) => Math.trunc(l / r),
 		ValueType.XSINTEGER,
 	],
 	// Integer Division, integer over numeric
-	[hash(ValueType.XSINTEGER , ValueType.XSNUMERIC, 'idiv')]: [
+	[hash(ValueType.XSINTEGER, ValueType.XSNUMERIC, 'idiv')]: [
 		(l: number, r: number) => Math.trunc(l / r),
 		ValueType.XSINTEGER,
 	],

--- a/src/typeInference/annotateBinaryOperator.ts
+++ b/src/typeInference/annotateBinaryOperator.ts
@@ -5,16 +5,16 @@ import {
 } from '../expressions/dataTypes/valueTypes/DateTime';
 import {
 	add as dayTimeDurationAdd,
-	subtract as dayTimeDurationSub,
 	divideByDayTimeDuration as dayTimeDurationDivideByDayTimeDuration,
 	multiply as dayTimeDurationMultiply,
+	subtract as dayTimeDurationSub,
 } from '../expressions/dataTypes/valueTypes/DayTimeDuration';
 import {
 	add as yearMonthDurationAdd,
-	subtract as yearMonthDurationSub,
 	divide as yearMonthDurationDivide,
 	divideByYearMonthDuration as yearMonthDurationDivideByYearMonthDuration,
 	multiply as yearMonthDurationMultiply,
+	subtract as yearMonthDurationSub,
 } from '../expressions/dataTypes/valueTypes/YearMonthDuration';
 import { IAST } from '../parsing/astHelper';
 import { BinaryEvaluationFunction } from './binaryEvaluationFunction';

--- a/src/typeInference/annotateBinaryOperator.ts
+++ b/src/typeInference/annotateBinaryOperator.ts
@@ -151,6 +151,72 @@ const BINOP_EVAL_FUNCTIONS: EvalFuncTable = {
 		yearMonthDurationDivide,
 		ValueType.XSDAYTIMEDURATION,
 	],
+
+	// Integer Division, numerator and denominator of the same type
+	[hash(ValueType.XSINTEGER, ValueType.XSINTEGER, 'idiv')]: [
+		(l: number, r: number) => Math.trunc(l / r),
+		ValueType.XSINTEGER,
+	],
+	[hash(ValueType.XSFLOAT, ValueType.XSFLOAT, 'idiv')]: [
+		(l: number, r: number) => Math.trunc(l / r),
+		ValueType.XSINTEGER,
+	],
+	[hash(ValueType.XSDOUBLE, ValueType.XSDOUBLE, 'idiv')]: [
+		(l: number, r: number) => Math.trunc(l / r),
+		ValueType.XSINTEGER,
+	],
+	[hash(ValueType.XSDECIMAL, ValueType.XSDECIMAL, 'idiv')]: [
+		(l: number, r: number) => Math.trunc(l / r),
+		ValueType.XSINTEGER,
+	],
+	[hash(ValueType.XSNUMERIC, ValueType.XSNUMERIC, 'idiv')]: [
+		(l: number, r: number) => Math.trunc(l / r),
+		ValueType.XSINTEGER,
+	],
+
+	// Integer Division, float over integer
+	[hash(ValueType.XSFLOAT, ValueType.XSINTEGER, 'idiv')]: [
+		(l: number, r: number) => Math.trunc(l / r),
+		ValueType.XSINTEGER,
+	],
+	// Integer Division, integer over float
+	[hash(ValueType.XSINTEGER, ValueType.XSFLOAT, 'idiv')]: [
+		(l: number, r: number) => Math.trunc(l / r),
+		ValueType.XSINTEGER,
+	],
+	
+	// Integer Division, double over integer
+	[hash(ValueType.XSDOUBLE, ValueType.XSINTEGER, 'idiv')]: [
+		(l: number, r: number) => Math.trunc(l / r),
+		ValueType.XSINTEGER,
+	],
+	// Integer Division, integer over double
+	[hash(ValueType.XSINTEGER, ValueType.XSDOUBLE, 'idiv')]: [
+		(l: number, r: number) => Math.trunc(l / r),
+		ValueType.XSINTEGER,
+	],
+	
+	// Integer Division, decimal over integer
+	[hash(ValueType.XSDECIMAL, ValueType.XSINTEGER, 'idiv')]: [
+		(l: number, r: number) => Math.trunc(l / r),
+		ValueType.XSINTEGER,
+	],
+	// Integer Division, integer over decimal
+	[hash(ValueType.XSINTEGER, ValueType.XSDECIMAL, 'idiv')]: [
+		(l: number, r: number) => Math.trunc(l / r),
+		ValueType.XSINTEGER,
+	],
+	
+	// Integer Division, numeric over integer
+	[hash(ValueType.XSNUMERIC, ValueType.XSINTEGER, 'idiv')]: [
+		(l: number, r: number) => Math.trunc(l / r),
+		ValueType.XSINTEGER,
+	],
+	// Integer Division, integer over numeric
+	[hash(ValueType.XSINTEGER , ValueType.XSNUMERIC, 'idiv')]: [
+		(l: number, r: number) => Math.trunc(l / r),
+		ValueType.XSINTEGER,
+	],
 };
 
 export function annotateBinOp(


### PR DESCRIPTION

# Merge Request

## Description

30 Added Integer Division to the Binary Operator Annotation, as titled.

Closes #30 

## Changes

1. Added an idivOP case to the switch in annotate()
2. Added integer division cases to the lookup table `BINOP_EVAL_FUNCTIONS`

## Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

## How Many Approvals?

* 1 Approval (Small bugs/hot fixes)
