### PR TITLE
Added castExpr and castableExpr type annotation to the AST

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,8 +59,6 @@ import {
 	Text,
 } from './types/Types';
 
-evaluateXPath('5.0 cast as xs:integer');
-
 function parseXPath(xpathString: string) {
 	const cachedExpression = getAnyStaticCompilationResultFromCache(xpathString, 'XPath', false);
 	if (cachedExpression) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,8 @@ import {
 	Text,
 } from './types/Types';
 
+evaluateXPath('5.0 cast as xs:integer');
+
 function parseXPath(xpathString: string) {
 	const cachedExpression = getAnyStaticCompilationResultFromCache(xpathString, 'XPath', false);
 	if (cachedExpression) {

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -1,6 +1,7 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import { IAST } from '../parsing/astHelper';
 import { annotateBinOp } from './annotateBinaryOperator';
+import { annotateCastOperators } from './annotateCastOperators';
 import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
 import { insertAttribute } from './insertAttribute';
 
@@ -61,6 +62,9 @@ export function annotate(ast: IAST): SequenceType | undefined {
 
 			insertAttribute(ast, 'type', stringSequenceType);
 			return stringSequenceType;
+		case 'castExpr':
+		case 'castableExpr':
+			return annotateCastOperators(ast);
 		default:
 			for (let i = 1; i < ast.length; i++) {
 				annotate(ast[i] as IAST);

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -1,7 +1,7 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import { IAST } from '../parsing/astHelper';
 import { annotateBinOp } from './annotateBinaryOperator';
-import { annotateCastOperators } from './annotateCastOperators';
+import { annotateCastableOperator, annotateCastOperator } from './annotateCastOperators';
 import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
 import { insertAttribute } from './insertAttribute';
 
@@ -63,8 +63,9 @@ export function annotate(ast: IAST): SequenceType | undefined {
 			insertAttribute(ast, 'type', stringSequenceType);
 			return stringSequenceType;
 		case 'castExpr':
+			return annotateCastOperator(ast);
 		case 'castableExpr':
-			return annotateCastOperators(ast);
+			return annotateCastableOperator(ast);
 		default:
 			for (let i = 1; i < ast.length; i++) {
 				annotate(ast[i] as IAST);

--- a/src/typeInference/annotateCastOperators.ts
+++ b/src/typeInference/annotateCastOperators.ts
@@ -1,0 +1,17 @@
+import {
+	SequenceMultiplicity,
+	SequenceType,
+	stringToValueType,
+} from '../expressions/dataTypes/Value';
+import { IAST } from '../parsing/astHelper';
+import { insertAttribute } from './insertAttribute';
+
+export function annotateCastOperators(ast: IAST): SequenceType | undefined {
+	// when ast is not annotated, ast[2] goes to the singleType, ast[2][1] the atomicType
+	// ast[2][1][1]['prefix'] the prefix 'xs' and then ast[2][1][2] is the targetType
+	const targetTypeFromAST = ast[2][1][1]['prefix'] + ':' + ast[2][1][2];
+	const valueType = stringToValueType(targetTypeFromAST);
+	const sequenceType = { type: valueType, mult: SequenceMultiplicity.EXACTLY_ONE };
+	insertAttribute(ast, 'type', sequenceType);
+	return sequenceType;
+}

--- a/src/typeInference/annotateCastOperators.ts
+++ b/src/typeInference/annotateCastOperators.ts
@@ -2,16 +2,23 @@ import {
 	SequenceMultiplicity,
 	SequenceType,
 	stringToValueType,
+	ValueType,
 } from '../expressions/dataTypes/Value';
 import { IAST } from '../parsing/astHelper';
 import { insertAttribute } from './insertAttribute';
 
-export function annotateCastOperators(ast: IAST): SequenceType | undefined {
+export function annotateCastOperator(ast: IAST): SequenceType | undefined {
 	// when ast is not annotated, ast[2] goes to the singleType, ast[2][1] the atomicType
 	// ast[2][1][1]['prefix'] the prefix 'xs' and then ast[2][1][2] is the targetType
 	const targetTypeFromAST = ast[2][1][1]['prefix'] + ':' + ast[2][1][2];
 	const valueType = stringToValueType(targetTypeFromAST);
 	const sequenceType = { type: valueType, mult: SequenceMultiplicity.EXACTLY_ONE };
+	insertAttribute(ast, 'type', sequenceType);
+	return sequenceType;
+}
+
+export function annotateCastableOperator(ast: IAST): SequenceType {
+	const sequenceType = { type: ValueType.XSBOOLEAN, mult: SequenceMultiplicity.EXACTLY_ONE };
 	insertAttribute(ast, 'type', sequenceType);
 	return sequenceType;
 }

--- a/src/typeInference/annotateCastOperators.ts
+++ b/src/typeInference/annotateCastOperators.ts
@@ -4,15 +4,13 @@ import {
 	stringToValueType,
 	ValueType,
 } from '../expressions/dataTypes/Value';
-import { IAST } from '../parsing/astHelper';
+import astHelper, { IAST } from '../parsing/astHelper';
 import { insertAttribute } from './insertAttribute';
 
 export function annotateCastOperator(ast: IAST): SequenceType | undefined {
-	// when ast is not annotated, ast[2] goes to the singleType, ast[2][1] the atomicType
-	// ast[2][1][1]['prefix'] the prefix 'xs' and then ast[2][1][2] is the targetType
-	const targetTypeFromAST = ast[2][1][1]['prefix'] + ':' + ast[2][1][2];
-	const valueType = stringToValueType(targetTypeFromAST);
-	const sequenceType = { type: valueType, mult: SequenceMultiplicity.EXACTLY_ONE };
+	const targetTypeString = getTargetTypeFromAST(ast);
+	const targetValueType = stringToValueType(targetTypeString);
+	const sequenceType = { type: targetValueType, mult: SequenceMultiplicity.EXACTLY_ONE };
 	insertAttribute(ast, 'type', sequenceType);
 	return sequenceType;
 }
@@ -21,4 +19,15 @@ export function annotateCastableOperator(ast: IAST): SequenceType {
 	const sequenceType = { type: ValueType.XSBOOLEAN, mult: SequenceMultiplicity.EXACTLY_ONE };
 	insertAttribute(ast, 'type', sequenceType);
 	return sequenceType;
+}
+
+function getTargetTypeFromAST(ast: IAST): string {
+	// ast[2][1] (castExpr, singleType, atomicType) contains the type information
+	// ast[2][1][1]['prefix'] the prefix 'xs' and then ast[2][1][2] is the targetType
+
+	const typeInfoNode = astHelper.followPath(ast, ['singleType', 'atomicType']);
+	const prefix = astHelper.getAttribute(typeInfoNode, 'prefix');
+	const targetType = typeInfoNode[2];
+
+	return prefix + ':' + targetType;
 }


### PR DESCRIPTION
## Description

Reading the target type from the ast and adding a uniformed type of information in the AST.

Closes #43

## Changes

1. New function that read the target type and annotate ast
2. New function that annotates castableExpr as boolean and returns the corresponding sequence type
3. New switch cases: `castExpr` and `castableExpr`

## Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

## How Many Approvals?

* 2 Approvals (Normal features and bugs)