### PR TITLE
54 move binop functions in ast

### DIFF
--- a/src/expressions/operators/arithmetic/BinaryEvaluationFunctionMap.ts
+++ b/src/expressions/operators/arithmetic/BinaryEvaluationFunctionMap.ts
@@ -1,0 +1,196 @@
+import { ValueType } from '../../../expressions/dataTypes/Value';
+import {
+	addDuration as addDurationToDateTime,
+	subtract as dateTimeSubtract,
+	subtractDuration as subtractDurationFromDateTime,
+} from '../../../expressions/dataTypes/valueTypes/DateTime';
+import {
+	add as dayTimeDurationAdd,
+	divide as dayTimeDurationDivide,
+	divideByDayTimeDuration as dayTimeDurationDivideByDayTimeDuration,
+	multiply as dayTimeDurationMultiply,
+	subtract as dayTimeDurationSubtract,
+} from '../../../expressions/dataTypes/valueTypes/DayTimeDuration';
+import {
+	add as yearMonthDurationAdd,
+	divide as yearMonthDurationDivide,
+	divideByYearMonthDuration as yearMonthDurationDivideByYearMonthDuration,
+	multiply as yearMonthDurationMultiply,
+	subtract as yearMonthDurationSubtract,
+} from '../../../expressions/dataTypes/valueTypes/YearMonthDuration';
+
+/**
+ * A hash function that is used to create the keys for the ruleMap.
+ * @param left the ValueType of the left part of the operator
+ * @param right the ValueType of the right part of the operator
+ * @param op the operator
+ * @returns a number that can be used as a key
+ */
+export function hash(left: ValueType, right: ValueType, op: string): number {
+	return (
+		((left as number) << 20) +
+		((right as number) << 12) +
+		(op.charCodeAt(0) << 8) +
+		op.charCodeAt(1)
+	);
+}
+
+type EvalFuncTable = {
+	[key: number]: [(a: any, b: any) => any, ValueType];
+};
+
+/**
+ * The map with every possible combination of operands.
+ * returns both a function that needs to be applied to the operands and the returnType of the operation.
+ */
+export const ruleMap: EvalFuncTable = {
+	[hash(ValueType.XSNUMERIC, ValueType.XSNUMERIC, 'addOp')]: [(a, b) => a + b, undefined],
+	[hash(ValueType.XSNUMERIC, ValueType.XSNUMERIC, 'subtractOp')]: [(a, b) => a - b, undefined],
+	[hash(ValueType.XSNUMERIC, ValueType.XSNUMERIC, 'multiplyOp')]: [(a, b) => a * b, undefined],
+	[hash(ValueType.XSNUMERIC, ValueType.XSNUMERIC, 'divOp')]: [(a, b) => a / b, undefined],
+	[hash(ValueType.XSNUMERIC, ValueType.XSNUMERIC, 'modOp')]: [(a, b) => a % b, undefined],
+	[hash(ValueType.XSNUMERIC, ValueType.XSNUMERIC, 'idivOp')]: [
+		(a, b) => Math.trunc(a / b),
+		ValueType.XSINTEGER,
+	],
+	[hash(ValueType.XSYEARMONTHDURATION, ValueType.XSYEARMONTHDURATION, 'addOp')]: [
+		yearMonthDurationAdd,
+		ValueType.XSYEARMONTHDURATION,
+	],
+	[hash(ValueType.XSYEARMONTHDURATION, ValueType.XSYEARMONTHDURATION, 'subtractOp')]: [
+		yearMonthDurationSubtract,
+		ValueType.XSYEARMONTHDURATION,
+	],
+	[hash(ValueType.XSYEARMONTHDURATION, ValueType.XSYEARMONTHDURATION, 'divOp')]: [
+		yearMonthDurationDivideByYearMonthDuration,
+		ValueType.XSDECIMAL,
+	],
+	[hash(ValueType.XSYEARMONTHDURATION, ValueType.XSNUMERIC, 'multiplyOp')]: [
+		yearMonthDurationMultiply,
+		ValueType.XSYEARMONTHDURATION,
+	],
+	[hash(ValueType.XSYEARMONTHDURATION, ValueType.XSNUMERIC, 'divOp')]: [
+		yearMonthDurationDivide,
+		ValueType.XSYEARMONTHDURATION,
+	],
+	[hash(ValueType.XSNUMERIC, ValueType.XSYEARMONTHDURATION, 'multiplyOp')]: [
+		(a, b) => yearMonthDurationMultiply(b, a),
+		ValueType.XSYEARMONTHDURATION,
+	],
+	[hash(ValueType.XSDAYTIMEDURATION, ValueType.XSDAYTIMEDURATION, 'addOp')]: [
+		dayTimeDurationAdd,
+		ValueType.XSDAYTIMEDURATION,
+	],
+	[hash(ValueType.XSDAYTIMEDURATION, ValueType.XSDAYTIMEDURATION, 'subtractOp')]: [
+		dayTimeDurationSubtract,
+		ValueType.XSDAYTIMEDURATION,
+	],
+	[hash(ValueType.XSDAYTIMEDURATION, ValueType.XSDAYTIMEDURATION, 'divOp')]: [
+		dayTimeDurationDivideByDayTimeDuration,
+		ValueType.XSDECIMAL,
+	],
+	[hash(ValueType.XSDAYTIMEDURATION, ValueType.XSNUMERIC, 'multiplyOp')]: [
+		dayTimeDurationMultiply,
+		ValueType.XSDAYTIMEDURATION,
+	],
+	[hash(ValueType.XSDAYTIMEDURATION, ValueType.XSNUMERIC, 'divOp')]: [
+		dayTimeDurationDivide,
+		ValueType.XSDAYTIMEDURATION,
+	],
+	[hash(ValueType.XSNUMERIC, ValueType.XSDAYTIMEDURATION, 'multiplyOp')]: [
+		(a, b) => dayTimeDurationMultiply(b, a),
+		ValueType.XSDAYTIMEDURATION,
+	],
+	[hash(ValueType.XSDATETIME, ValueType.XSDATETIME, 'subtractOp')]: [
+		dateTimeSubtract,
+		ValueType.XSDAYTIMEDURATION,
+	],
+	[hash(ValueType.XSDATE, ValueType.XSDATE, 'subtractOp')]: [
+		dateTimeSubtract,
+		ValueType.XSDAYTIMEDURATION,
+	],
+	[hash(ValueType.XSTIME, ValueType.XSTIME, 'subtractOp')]: [
+		dateTimeSubtract,
+		ValueType.XSDAYTIMEDURATION,
+	],
+	[hash(ValueType.XSDATETIME, ValueType.XSYEARMONTHDURATION, 'addOp')]: [
+		addDurationToDateTime,
+		ValueType.XSDATETIME,
+	],
+	[hash(ValueType.XSDATETIME, ValueType.XSYEARMONTHDURATION, 'subtractOp')]: [
+		subtractDurationFromDateTime,
+		ValueType.XSDATETIME,
+	],
+	[hash(ValueType.XSDATETIME, ValueType.XSDAYTIMEDURATION, 'addOp')]: [
+		addDurationToDateTime,
+		ValueType.XSDATETIME,
+	],
+	[hash(ValueType.XSDATETIME, ValueType.XSDAYTIMEDURATION, 'subtractOp')]: [
+		subtractDurationFromDateTime,
+		ValueType.XSDATETIME,
+	],
+	[hash(ValueType.XSDATE, ValueType.XSYEARMONTHDURATION, 'addOp')]: [
+		addDurationToDateTime,
+		ValueType.XSDATE,
+	],
+	[hash(ValueType.XSDATE, ValueType.XSYEARMONTHDURATION, 'subtractOp')]: [
+		subtractDurationFromDateTime,
+		ValueType.XSDATE,
+	],
+	[hash(ValueType.XSDATE, ValueType.XSDAYTIMEDURATION, 'addOp')]: [
+		addDurationToDateTime,
+		ValueType.XSDATE,
+	],
+	[hash(ValueType.XSDATE, ValueType.XSDAYTIMEDURATION, 'subtractOp')]: [
+		subtractDurationFromDateTime,
+		ValueType.XSDATE,
+	],
+	[hash(ValueType.XSTIME, ValueType.XSDAYTIMEDURATION, 'addOp')]: [
+		addDurationToDateTime,
+		ValueType.XSTIME,
+	],
+	[hash(ValueType.XSTIME, ValueType.XSDAYTIMEDURATION, 'subtractOp')]: [
+		subtractDurationFromDateTime,
+		ValueType.XSTIME,
+	],
+	[hash(ValueType.XSDATETIME, ValueType.XSYEARMONTHDURATION, 'addOp')]: [
+		addDurationToDateTime,
+		ValueType.XSDATETIME,
+	],
+	[hash(ValueType.XSDATETIME, ValueType.XSYEARMONTHDURATION, 'subtractOp')]: [
+		subtractDurationFromDateTime,
+		ValueType.XSDATETIME,
+	],
+	[hash(ValueType.XSDATETIME, ValueType.XSDAYTIMEDURATION, 'addOp')]: [
+		addDurationToDateTime,
+		ValueType.XSDATETIME,
+	],
+	[hash(ValueType.XSDATETIME, ValueType.XSDAYTIMEDURATION, 'subtractOp')]: [
+		subtractDurationFromDateTime,
+		ValueType.XSDATETIME,
+	],
+	[hash(ValueType.XSDATE, ValueType.XSDAYTIMEDURATION, 'addOp')]: [
+		addDurationToDateTime,
+		ValueType.XSDATE,
+	],
+	[hash(ValueType.XSDATE, ValueType.XSDAYTIMEDURATION, 'subtractOp')]: [
+		subtractDurationFromDateTime,
+		ValueType.XSDATE,
+	],
+	[hash(ValueType.XSDATE, ValueType.XSYEARMONTHDURATION, 'addOp')]: [
+		addDurationToDateTime,
+		ValueType.XSDATE,
+	],
+	[hash(ValueType.XSDATE, ValueType.XSYEARMONTHDURATION, 'subtractOp')]: [
+		subtractDurationFromDateTime,
+		ValueType.XSDATE,
+	],
+	[hash(ValueType.XSTIME, ValueType.XSDAYTIMEDURATION, 'addOp')]: [
+		addDurationToDateTime,
+		ValueType.XSTIME,
+	],
+	[hash(ValueType.XSTIME, ValueType.XSDAYTIMEDURATION, 'subtractOp')]: [
+		subtractDurationFromDateTime,
+		ValueType.XSTIME,
+	],
+};

--- a/src/expressions/operators/arithmetic/BinaryOperator.ts
+++ b/src/expressions/operators/arithmetic/BinaryOperator.ts
@@ -3,30 +3,12 @@ import castToType from '../../../expressions/dataTypes/castToType';
 import createAtomicValue from '../../../expressions/dataTypes/createAtomicValue';
 import isSubtypeOf from '../../../expressions/dataTypes/isSubtypeOf';
 import { ValueType } from '../../../expressions/dataTypes/Value';
-import {
-	addDuration as addDurationToDateTime,
-	subtract as dateTimeSubtract,
-	subtractDuration as subtractDurationFromDateTime,
-} from '../../../expressions/dataTypes/valueTypes/DateTime';
-import {
-	add as dayTimeDurationAdd,
-	divide as dayTimeDurationDivide,
-	divideByDayTimeDuration as dayTimeDurationDivideByDayTimeDuration,
-	multiply as dayTimeDurationMultiply,
-	subtract as dayTimeDurationSubtract,
-} from '../../../expressions/dataTypes/valueTypes/DayTimeDuration';
-import {
-	add as yearMonthDurationAdd,
-	divide as yearMonthDurationDivide,
-	divideByYearMonthDuration as yearMonthDurationDivideByYearMonthDuration,
-	multiply as yearMonthDurationMultiply,
-	subtract as yearMonthDurationSubtract,
-} from '../../../expressions/dataTypes/valueTypes/YearMonthDuration';
 import { BinaryEvaluationFunction } from '../../../typeInference/binaryEvaluationFunction';
 import atomize from '../../dataTypes/atomize';
 import sequenceFactory from '../../dataTypes/sequenceFactory';
 import { SequenceType } from '../../dataTypes/Value';
 import Expression from '../../Expression';
+import { ruleMap, hash } from '../arithmetic/BinaryEvaluationFunctionMap';
 
 function determineReturnType(typeA: ValueType, typeB: ValueType): ValueType {
 	if (isSubtypeOf(typeA, ValueType.XSINTEGER) && isSubtypeOf(typeB, ValueType.XSINTEGER)) {
@@ -54,189 +36,13 @@ const allTypes = [
 ];
 
 /**
- * A hash function that is used to create the keys for the ruleMap.
- * @param left the ValueType of the left part of the operator
- * @param right the ValueType of the right part of the operator
- * @param op the operator
- * @returns a number that can be used as a key
- */
-function hash(left: ValueType, right: ValueType, op: string): number {
-	return (
-		((left as number) << 20) +
-		((right as number) << 12) +
-		(op.charCodeAt(0) << 8) +
-		op.charCodeAt(1)
-	);
-}
-
-type EvalFuncTable = {
-	[key: number]: [(a: any, b: any) => any, ValueType];
-};
-
-/**
- * The map with every possible combination of operands.
- * returns both a function that needs to be applied to the operands and the returnType of the operation.
- */
-const ruleMap: EvalFuncTable = {
-	[hash(ValueType.XSNUMERIC, ValueType.XSNUMERIC, 'addOp')]: [(a, b) => a + b, undefined],
-	[hash(ValueType.XSNUMERIC, ValueType.XSNUMERIC, 'subtractOp')]: [(a, b) => a - b, undefined],
-	[hash(ValueType.XSNUMERIC, ValueType.XSNUMERIC, 'multiplyOp')]: [(a, b) => a * b, undefined],
-	[hash(ValueType.XSNUMERIC, ValueType.XSNUMERIC, 'divOp')]: [(a, b) => a / b, undefined],
-	[hash(ValueType.XSNUMERIC, ValueType.XSNUMERIC, 'modOp')]: [(a, b) => a % b, undefined],
-	[hash(ValueType.XSNUMERIC, ValueType.XSNUMERIC, 'idivOp')]: [
-		(a, b) => Math.trunc(a / b),
-		ValueType.XSINTEGER,
-	],
-	[hash(ValueType.XSYEARMONTHDURATION, ValueType.XSYEARMONTHDURATION, 'addOp')]: [
-		yearMonthDurationAdd,
-		ValueType.XSYEARMONTHDURATION,
-	],
-	[hash(ValueType.XSYEARMONTHDURATION, ValueType.XSYEARMONTHDURATION, 'subtractOp')]: [
-		yearMonthDurationSubtract,
-		ValueType.XSYEARMONTHDURATION,
-	],
-	[hash(ValueType.XSYEARMONTHDURATION, ValueType.XSYEARMONTHDURATION, 'divOp')]: [
-		yearMonthDurationDivideByYearMonthDuration,
-		ValueType.XSDECIMAL,
-	],
-	[hash(ValueType.XSYEARMONTHDURATION, ValueType.XSNUMERIC, 'multiplyOp')]: [
-		yearMonthDurationMultiply,
-		ValueType.XSYEARMONTHDURATION,
-	],
-	[hash(ValueType.XSYEARMONTHDURATION, ValueType.XSNUMERIC, 'divOp')]: [
-		yearMonthDurationDivide,
-		ValueType.XSYEARMONTHDURATION,
-	],
-	[hash(ValueType.XSNUMERIC, ValueType.XSYEARMONTHDURATION, 'multiplyOp')]: [
-		(a, b) => yearMonthDurationMultiply(b, a),
-		ValueType.XSYEARMONTHDURATION,
-	],
-	[hash(ValueType.XSDAYTIMEDURATION, ValueType.XSDAYTIMEDURATION, 'addOp')]: [
-		dayTimeDurationAdd,
-		ValueType.XSDAYTIMEDURATION,
-	],
-	[hash(ValueType.XSDAYTIMEDURATION, ValueType.XSDAYTIMEDURATION, 'subtractOp')]: [
-		dayTimeDurationSubtract,
-		ValueType.XSDAYTIMEDURATION,
-	],
-	[hash(ValueType.XSDAYTIMEDURATION, ValueType.XSDAYTIMEDURATION, 'divOp')]: [
-		dayTimeDurationDivideByDayTimeDuration,
-		ValueType.XSDECIMAL,
-	],
-	[hash(ValueType.XSDAYTIMEDURATION, ValueType.XSNUMERIC, 'multiplyOp')]: [
-		dayTimeDurationMultiply,
-		ValueType.XSDAYTIMEDURATION,
-	],
-	[hash(ValueType.XSDAYTIMEDURATION, ValueType.XSNUMERIC, 'divOp')]: [
-		dayTimeDurationDivide,
-		ValueType.XSDAYTIMEDURATION,
-	],
-	[hash(ValueType.XSNUMERIC, ValueType.XSDAYTIMEDURATION, 'multiplyOp')]: [
-		(a, b) => dayTimeDurationMultiply(b, a),
-		ValueType.XSDAYTIMEDURATION,
-	],
-	[hash(ValueType.XSDATETIME, ValueType.XSDATETIME, 'subtractOp')]: [
-		dateTimeSubtract,
-		ValueType.XSDAYTIMEDURATION,
-	],
-	[hash(ValueType.XSDATE, ValueType.XSDATE, 'subtractOp')]: [
-		dateTimeSubtract,
-		ValueType.XSDAYTIMEDURATION,
-	],
-	[hash(ValueType.XSTIME, ValueType.XSTIME, 'subtractOp')]: [
-		dateTimeSubtract,
-		ValueType.XSDAYTIMEDURATION,
-	],
-	[hash(ValueType.XSDATETIME, ValueType.XSYEARMONTHDURATION, 'addOp')]: [
-		addDurationToDateTime,
-		ValueType.XSDATETIME,
-	],
-	[hash(ValueType.XSDATETIME, ValueType.XSYEARMONTHDURATION, 'subtractOp')]: [
-		subtractDurationFromDateTime,
-		ValueType.XSDATETIME,
-	],
-	[hash(ValueType.XSDATETIME, ValueType.XSDAYTIMEDURATION, 'addOp')]: [
-		addDurationToDateTime,
-		ValueType.XSDATETIME,
-	],
-	[hash(ValueType.XSDATETIME, ValueType.XSDAYTIMEDURATION, 'subtractOp')]: [
-		subtractDurationFromDateTime,
-		ValueType.XSDATETIME,
-	],
-	[hash(ValueType.XSDATE, ValueType.XSYEARMONTHDURATION, 'addOp')]: [
-		addDurationToDateTime,
-		ValueType.XSDATE,
-	],
-	[hash(ValueType.XSDATE, ValueType.XSYEARMONTHDURATION, 'subtractOp')]: [
-		subtractDurationFromDateTime,
-		ValueType.XSDATE,
-	],
-	[hash(ValueType.XSDATE, ValueType.XSDAYTIMEDURATION, 'addOp')]: [
-		addDurationToDateTime,
-		ValueType.XSDATE,
-	],
-	[hash(ValueType.XSDATE, ValueType.XSDAYTIMEDURATION, 'subtractOp')]: [
-		subtractDurationFromDateTime,
-		ValueType.XSDATE,
-	],
-	[hash(ValueType.XSTIME, ValueType.XSDAYTIMEDURATION, 'addOp')]: [
-		addDurationToDateTime,
-		ValueType.XSTIME,
-	],
-	[hash(ValueType.XSTIME, ValueType.XSDAYTIMEDURATION, 'subtractOp')]: [
-		subtractDurationFromDateTime,
-		ValueType.XSTIME,
-	],
-	[hash(ValueType.XSDATETIME, ValueType.XSYEARMONTHDURATION, 'addOp')]: [
-		addDurationToDateTime,
-		ValueType.XSDATETIME,
-	],
-	[hash(ValueType.XSDATETIME, ValueType.XSYEARMONTHDURATION, 'subtractOp')]: [
-		subtractDurationFromDateTime,
-		ValueType.XSDATETIME,
-	],
-	[hash(ValueType.XSDATETIME, ValueType.XSDAYTIMEDURATION, 'addOp')]: [
-		addDurationToDateTime,
-		ValueType.XSDATETIME,
-	],
-	[hash(ValueType.XSDATETIME, ValueType.XSDAYTIMEDURATION, 'subtractOp')]: [
-		subtractDurationFromDateTime,
-		ValueType.XSDATETIME,
-	],
-	[hash(ValueType.XSDATE, ValueType.XSDAYTIMEDURATION, 'addOp')]: [
-		addDurationToDateTime,
-		ValueType.XSDATE,
-	],
-	[hash(ValueType.XSDATE, ValueType.XSDAYTIMEDURATION, 'subtractOp')]: [
-		subtractDurationFromDateTime,
-		ValueType.XSDATE,
-	],
-	[hash(ValueType.XSDATE, ValueType.XSYEARMONTHDURATION, 'addOp')]: [
-		addDurationToDateTime,
-		ValueType.XSDATE,
-	],
-	[hash(ValueType.XSDATE, ValueType.XSYEARMONTHDURATION, 'subtractOp')]: [
-		subtractDurationFromDateTime,
-		ValueType.XSDATE,
-	],
-	[hash(ValueType.XSTIME, ValueType.XSDAYTIMEDURATION, 'addOp')]: [
-		addDurationToDateTime,
-		ValueType.XSTIME,
-	],
-	[hash(ValueType.XSTIME, ValueType.XSDAYTIMEDURATION, 'subtractOp')]: [
-		subtractDurationFromDateTime,
-		ValueType.XSTIME,
-	],
-};
-
-/**
  * Generates the BinaryOperatorFunction given the 3 input values.
  * @param operator The operator of the operation.
  * @param typeA The type of the left part of the operation
  * @param typeB The type of the right part of the operation
  * @returns A tuple of a function that needs to be applied to the operands and the returnType of the operation.
  */
-function generateBinaryOperatorFunction(
+export function generateBinaryOperatorFunction(
 	operator: string,
 	typeA: ValueType,
 	typeB: ValueType

--- a/src/expressions/operators/arithmetic/BinaryOperator.ts
+++ b/src/expressions/operators/arithmetic/BinaryOperator.ts
@@ -8,7 +8,7 @@ import atomize from '../../dataTypes/atomize';
 import sequenceFactory from '../../dataTypes/sequenceFactory';
 import { SequenceType } from '../../dataTypes/Value';
 import Expression from '../../Expression';
-import { ruleMap, hash } from '../arithmetic/BinaryEvaluationFunctionMap';
+import { hash, ruleMap } from '../arithmetic/BinaryEvaluationFunctionMap';
 
 function determineReturnType(typeA: ValueType, typeB: ValueType): ValueType {
 	if (isSubtypeOf(typeA, ValueType.XSINTEGER) && isSubtypeOf(typeB, ValueType.XSINTEGER)) {

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -23,7 +23,9 @@ import LetExpression from '../expressions/LetExpression';
 import Literal from '../expressions/literals/Literal';
 import MapConstructor from '../expressions/maps/MapConstructor';
 import NamedFunctionRef from '../expressions/NamedFunctionRef';
-import BinaryOperator from '../expressions/operators/arithmetic/BinaryOperator';
+import BinaryOperator, {
+	generateBinaryOperatorFunction,
+} from '../expressions/operators/arithmetic/BinaryOperator';
 import Unary from '../expressions/operators/arithmetic/Unary';
 import AndOperator from '../expressions/operators/boolean/AndOperator';
 import OrOperator from '../expressions/operators/boolean/OrOperator';
@@ -364,7 +366,21 @@ function binaryOperator(ast: IAST, compilationOptions: CompilationOptions) {
 	);
 
 	const attributeType = astHelper.getAttribute(ast, 'type');
-	const evaluateFunction = astHelper.getAttribute(ast, 'evalFunc');
+	const first = astHelper.getAttribute(
+		astHelper.followPath(ast, ['firstOperand', '*']),
+		'type'
+	) as SequenceType;
+	const second = astHelper.getAttribute(
+		astHelper.followPath(ast, ['secondOperand', '*']),
+		'type'
+	) as SequenceType;
+	let firstType, secondType;
+	let evaluateFunction;
+	if (first && second) {
+		firstType = first.type;
+		secondType = second.type;
+		evaluateFunction = generateBinaryOperatorFunction(kind, firstType, secondType)[0];
+	}
 
 	return new BinaryOperator(
 		kind,

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -374,7 +374,8 @@ function binaryOperator(ast: IAST, compilationOptions: CompilationOptions) {
 		astHelper.followPath(ast, ['secondOperand', '*']),
 		'type'
 	) as SequenceType;
-	let firstType, secondType;
+	let firstType;
+	let secondType;
 	let evaluateFunction;
 	if (first && second) {
 		firstType = first.type;

--- a/src/typeInference/annotateBinaryOperator.ts
+++ b/src/typeInference/annotateBinaryOperator.ts
@@ -21,7 +21,6 @@ export function annotateBinOp(
 	if (funcData) {
 		const type = { type: funcData[1], mult: left.mult };
 		astHelper.insertAttribute(ast, 'type', type);
-		astHelper.insertAttribute(ast, 'evalFunc', funcData[0]);
 		return type;
 	}
 


### PR DESCRIPTION
# Pull Request

## Description

Removed the functions from the ast and cleaned up binaryoperator

Closes #54 

## Changes

1. Removed the functions from the ast
2. Moved binOpMap to seperate file

## Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

## How Many Approvals?

* 2 Approvals (Normal features and bugs)