### PR TITLE
WIP: Introduce AnnotationContext Flwor annotation

### DIFF
--- a/src/typeInference/AnnotatationContext.ts
+++ b/src/typeInference/AnnotatationContext.ts
@@ -1,0 +1,48 @@
+import { SequenceType } from '../expressions/dataTypes/Value';
+import StaticContext from '../expressions/StaticContext';
+
+export class AnnotationContext {
+	private _variableScope: { [key: string]: SequenceType }[];
+	private _scopeIndex: number = 0;
+	public staticContext?: StaticContext;
+
+	constructor(staticContext?: StaticContext) {
+		this.staticContext = staticContext;
+		this._variableScope = [{}];
+	}
+
+	public insertVariable(varName: string, varType: SequenceType): void {
+		if (this._variableScope[this._scopeIndex][varName]) {
+			// TODO: change the error being thrown in here to adhere the "error code" code.
+			throw new Error(
+				`Another variable of in the scope ${this._scopeIndex} with the same name ${varName} already exists`
+			);
+		}
+
+		this._variableScope[this._scopeIndex][varName] = varType;
+	}
+
+	public getVariable(varName: string): SequenceType {
+		for (let i = this._scopeIndex; i >= 0; i--) {
+			const variableType = this._variableScope[i][varName];
+			return variableType;
+		}
+
+		throw new Error('XPST0008, The variable ' + varName + ' is not in scope.');
+	}
+
+	public pushScope(): void {
+		this._scopeIndex++;
+		this._variableScope.push({});
+	}
+
+	public popScope(): void {
+		if (this._scopeIndex > 0) {
+			this._scopeIndex--;
+			this._variableScope.pop();
+			return;
+		}
+
+		throw new Error('Variable scope out of bound');
+	}
+}

--- a/src/typeInference/AnnotatationContext.ts
+++ b/src/typeInference/AnnotatationContext.ts
@@ -2,13 +2,23 @@ import { SequenceType } from '../expressions/dataTypes/Value';
 import StaticContext from '../expressions/StaticContext';
 
 export class AnnotationContext {
-	private _variableScope: { [key: string]: SequenceType }[];
-	private _scopeIndex: number = 0;
 	public staticContext?: StaticContext;
+
+	private _scopeIndex: number = 0;
+	private _variableScope: { [key: string]: SequenceType }[];
 
 	constructor(staticContext?: StaticContext) {
 		this.staticContext = staticContext;
 		this._variableScope = [{}];
+	}
+
+	public getVariable(varName: string): SequenceType {
+		for (let i = this._scopeIndex; i >= 0; i--) {
+			const variableType = this._variableScope[i][varName];
+			return variableType;
+		}
+
+		throw new Error('XPST0008, The variable ' + varName + ' is not in scope.');
 	}
 
 	public insertVariable(varName: string, varType: SequenceType): void {
@@ -22,20 +32,6 @@ export class AnnotationContext {
 		this._variableScope[this._scopeIndex][varName] = varType;
 	}
 
-	public getVariable(varName: string): SequenceType {
-		for (let i = this._scopeIndex; i >= 0; i--) {
-			const variableType = this._variableScope[i][varName];
-			return variableType;
-		}
-
-		throw new Error('XPST0008, The variable ' + varName + ' is not in scope.');
-	}
-
-	public pushScope(): void {
-		this._scopeIndex++;
-		this._variableScope.push({});
-	}
-
 	public popScope(): void {
 		if (this._scopeIndex > 0) {
 			this._scopeIndex--;
@@ -44,5 +40,10 @@ export class AnnotationContext {
 		}
 
 		throw new Error('Variable scope out of bound');
+	}
+
+	public pushScope(): void {
+		this._scopeIndex++;
+		this._variableScope.push({});
 	}
 }

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -156,11 +156,11 @@ export function annotate(
 			return annotateCastableOperator(ast);
 		// Current node cannot be annotated, but maybe deeper ones can.
 		case 'flworExpr':
-			return annotateFlworExpression(ast, annotationContext);
+			return annotateFlworExpression(ast, annotationContext, annotate);
 		default:
 			// Current node cannot be annotated, but maybe deeper ones can.
 			for (let i = 1; i < ast.length; i++) {
-				annotate(ast[i] as IAST, annotationContext);
+				const returnType = annotate(ast[i] as IAST, annotationContext);
 			}
 			return undefined;
 	}

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -22,7 +22,10 @@ import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
  * @param ast The AST to annotate
  * @param staticContext The static context used for function lookups
  */
-export function annotateAST(ast: IAST, staticContext: StaticContext): SequenceType | undefined {
+export default function annotateAST(
+	ast: IAST,
+	staticContext: StaticContext
+): SequenceType | undefined {
 	const annotationContext: AnnotationContext = new AnnotationContext(staticContext);
 	const type = annotate(ast, annotationContext);
 	return type;

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -22,13 +22,9 @@ import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
  * @param ast The AST to annotate
  * @param staticContext The static context used for function lookups
  */
-export default function annotateAST(
-	ast: IAST,
-	staticContext: StaticContext
-): SequenceType | undefined {
+export default function annotateAst(ast: IAST, staticContext?: StaticContext) {
 	const annotationContext: AnnotationContext = new AnnotationContext(staticContext);
-	const type = annotate(ast, annotationContext);
-	return type;
+	annotate(ast, annotationContext);
 }
 
 /**

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -9,7 +9,7 @@ import {
 	annotateNodeCompare,
 	annotateValueCompare,
 } from './annotateCompareOperator';
-import { annotateFlworExpression } from './annotateFlworExpression';
+import { annotateFlworExpression, annotateVarRef } from './annotateFlworExpression';
 import { annotateFunctionCall } from './annotateFunctionCall';
 import { annotateLogicalOperator } from './annotateLogicalOperator';
 import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
@@ -157,10 +157,18 @@ export function annotate(
 		// Current node cannot be annotated, but maybe deeper ones can.
 		case 'flworExpr':
 			return annotateFlworExpression(ast, annotationContext, annotate);
+		case 'varRef':
+			return annotateVarRef(ast[1] as IAST, annotationContext);
+		case 'returnClause':
+			const pathFollowed: IAST = astHelper.followPath(ast, ['*']);
+			const returnType = annotate(pathFollowed, annotationContext);
+			astHelper.insertAttribute(pathFollowed, 'type', returnType);
+			astHelper.insertAttribute(ast as IAST, 'type', returnType);
+			return returnType;
 		default:
 			// Current node cannot be annotated, but maybe deeper ones can.
 			for (let i = 1; i < ast.length; i++) {
-				const returnType = annotate(ast[i] as IAST, annotationContext);
+				annotate(ast[i] as IAST, annotationContext);
 			}
 			return undefined;
 	}

--- a/src/typeInference/annotateArrowExpr.ts
+++ b/src/typeInference/annotateArrowExpr.ts
@@ -1,6 +1,6 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
-import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './AnnotatationContext';
 
 /**
  * Annotate the arrowExpr by extracting the function info from the static context
@@ -12,10 +12,10 @@ import astHelper, { IAST } from '../parsing/astHelper';
  */
 export function annotateArrowExpr(
 	ast: IAST,
-	staticContext: StaticContext
+	annotationContext: AnnotationContext
 ): SequenceType | undefined {
 	// We need the context to lookup the function information
-	if (!staticContext) return undefined;
+	if (!annotationContext || !annotationContext.staticContext) return undefined;
 
 	const func = astHelper.getFirstChild(ast, 'EQName');
 
@@ -38,7 +38,7 @@ export function annotateArrowExpr(
 	const functionArguments = astHelper.getChildren(astHelper.getFirstChild(ast, 'arguments'), '*');
 
 	// Lookup the namespace URI
-	const resolvedName = staticContext.resolveFunctionName(
+	const resolvedName = annotationContext.staticContext.resolveFunctionName(
 		{
 			localName: functionName,
 			prefix: functionPrefix['prefix'] as string,
@@ -49,7 +49,7 @@ export function annotateArrowExpr(
 	if (!resolvedName) return undefined;
 
 	// Lookup the function properties (return type)
-	const functionProps = staticContext.lookupFunction(
+	const functionProps = annotationContext.staticContext.lookupFunction(
 		resolvedName.namespaceURI,
 		resolvedName.localName,
 		functionArguments.length

--- a/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
+++ b/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
@@ -1,6 +1,6 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
-import StaticContext from '../expressions/StaticContext';
 import { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './AnnotatationContext';
 
 /**
  * At this moment there is no way to infer the return type of this function as
@@ -14,7 +14,7 @@ import { IAST } from '../parsing/astHelper';
  */
 export function annotateDynamicFunctionInvocationExpr(
 	ast: IAST,
-	staticContext: StaticContext,
+	annotationContext: AnnotationContext,
 	functionItem: SequenceType,
 	args: SequenceType
 ): SequenceType {

--- a/src/typeInference/annotateFlworExpression.ts
+++ b/src/typeInference/annotateFlworExpression.ts
@@ -1,0 +1,36 @@
+import { SequenceType } from '../expressions/dataTypes/Value';
+import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './AnnotatationContext';
+import { annotate } from './annotateAST';
+
+export function annotateFlworExpression(
+	ast: IAST,
+	annotationContext: AnnotationContext
+): SequenceType {
+	let returnType = undefined;
+
+	for (let i = 1; i < ast.length; i++) {
+		switch (ast[i][0]) {
+			case 'letClause':
+				annotateLetClause(ast[i] as IAST, annotationContext);
+			case 'returnClause':
+				returnType = annotate(ast[i] as IAST, annotationContext);
+				astHelper.insertAttribute(ast, 'type', returnType);
+		}
+	}
+
+	return returnType;
+}
+
+function annotateLetClause(ast: IAST, annotationContext: AnnotationContext): void {
+	const pathToVarName: string[] = ['letClauseItem', 'typedVariableBinding', 'varName'];
+	const varNameNode: IAST = astHelper.followPath(ast, pathToVarName);
+	const varName = varNameNode[1] as string;
+
+	const pathToVarType: string[] = ['letClauseItem', 'letExpr'];
+	const varTypeNode: IAST = astHelper.followPath(ast, pathToVarType);
+
+	const varType: SequenceType = annotate(varTypeNode[1] as IAST, annotationContext);
+
+	annotationContext.insertVariable(varName, varType);
+}

--- a/src/typeInference/annotateFlworExpression.ts
+++ b/src/typeInference/annotateFlworExpression.ts
@@ -5,21 +5,20 @@ import { AnnotationContext } from './AnnotatationContext';
 export function annotateFlworExpression(
 	ast: IAST,
 	annotationContext: AnnotationContext
-): SequenceType {
-	let returnType = undefined;
-
+): SequenceType | undefined {
 	for (let i = 1; i < ast.length; i++) {
 		switch (ast[i][0]) {
 			case 'letClause':
 				annotateLetClause(ast[i] as IAST, annotationContext);
 			case 'returnClause':
-				// unable to execute, circular import
-				// returnType = annotate(ast[i] as IAST, annotationContext);
-				astHelper.insertAttribute(ast, 'type', returnType);
+			// unable to execute, circular import
+			// returnType = annotate(ast[i] as IAST, annotationContext);
+			// astHelper.insertAttribute(ast, 'type', returnType);
+			// return returnType
 		}
 	}
 
-	return returnType;
+	return undefined;
 }
 
 function annotateLetClause(ast: IAST, annotationContext: AnnotationContext): void {

--- a/src/typeInference/annotateFlworExpression.ts
+++ b/src/typeInference/annotateFlworExpression.ts
@@ -4,24 +4,36 @@ import { AnnotationContext } from './AnnotatationContext';
 
 export function annotateFlworExpression(
 	ast: IAST,
-	annotationContext: AnnotationContext
+	annotationContext: AnnotationContext,
+	annotate: (ast: IAST, annotationContext) => SequenceType
 ): SequenceType | undefined {
 	for (let i = 1; i < ast.length; i++) {
 		switch (ast[i][0]) {
 			case 'letClause':
-				annotateLetClause(ast[i] as IAST, annotationContext);
+				annotateLetClause(ast[i] as IAST, annotationContext, annotate);
+				break;
 			case 'returnClause':
-			// unable to execute, circular import
-			// returnType = annotate(ast[i] as IAST, annotationContext);
-			// astHelper.insertAttribute(ast, 'type', returnType);
-			// return returnType
+				// ast[i][1] is the varRef child node from the returnClause node
+				const returnType = annotateFlworExpression(
+					ast[i] as IAST,
+					annotationContext,
+					annotate
+				);
+				astHelper.insertAttribute(ast, 'type', returnType);
+				return returnType;
+			case 'varRef':
+				return annotateReturnClause(ast[1] as IAST, annotationContext);
 		}
 	}
 
 	return undefined;
 }
 
-function annotateLetClause(ast: IAST, annotationContext: AnnotationContext): void {
+function annotateLetClause(
+	ast: IAST,
+	annotationContext: AnnotationContext,
+	annotate: (ast: IAST, annotationContext) => SequenceType
+): void {
 	const pathToVarName: string[] = ['letClauseItem', 'typedVariableBinding', 'varName'];
 	const varNameNode: IAST = astHelper.followPath(ast, pathToVarName);
 	const varName = varNameNode[1] as string;
@@ -29,8 +41,17 @@ function annotateLetClause(ast: IAST, annotationContext: AnnotationContext): voi
 	const pathToVarType: string[] = ['letClauseItem', 'letExpr'];
 	const varTypeNode: IAST = astHelper.followPath(ast, pathToVarType);
 
-	// unable to execute, circular import
-	// const varType: SequenceType = annotate(varTypeNode[1] as IAST, annotationContext);
+	const varType: SequenceType = annotate(varTypeNode[1] as IAST, annotationContext);
 
-	// annotationContext.insertVariable(varName, varType);
+	annotationContext.insertVariable(varName, varType);
+}
+
+function annotateReturnClause(ast: IAST, annotationContext: AnnotationContext): SequenceType {
+	// pass ast sub tree with the ast[0] as `varRef` to this function
+	// ast[1] here would be the array of the variables to be returned
+	// ast[1][0] always seems to be `name`?
+	const varName: string = ast[1][1];
+	const varType: SequenceType = annotationContext.getVariable(varName);
+
+	return varType;
 }

--- a/src/typeInference/annotateFlworExpression.ts
+++ b/src/typeInference/annotateFlworExpression.ts
@@ -1,7 +1,6 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
 import { AnnotationContext } from './AnnotatationContext';
-import { annotate } from './annotateAST';
 
 export function annotateFlworExpression(
 	ast: IAST,
@@ -14,7 +13,8 @@ export function annotateFlworExpression(
 			case 'letClause':
 				annotateLetClause(ast[i] as IAST, annotationContext);
 			case 'returnClause':
-				returnType = annotate(ast[i] as IAST, annotationContext);
+				// unable to execute, circular import
+				// returnType = annotate(ast[i] as IAST, annotationContext);
 				astHelper.insertAttribute(ast, 'type', returnType);
 		}
 	}
@@ -30,7 +30,8 @@ function annotateLetClause(ast: IAST, annotationContext: AnnotationContext): voi
 	const pathToVarType: string[] = ['letClauseItem', 'letExpr'];
 	const varTypeNode: IAST = astHelper.followPath(ast, pathToVarType);
 
-	const varType: SequenceType = annotate(varTypeNode[1] as IAST, annotationContext);
+	// unable to execute, circular import
+	// const varType: SequenceType = annotate(varTypeNode[1] as IAST, annotationContext);
 
-	annotationContext.insertVariable(varName, varType);
+	// annotationContext.insertVariable(varName, varType);
 }

--- a/src/typeInference/annotateFunctionCall.ts
+++ b/src/typeInference/annotateFunctionCall.ts
@@ -1,18 +1,18 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
-import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './AnnotatationContext';
 
 export function annotateFunctionCall(
 	ast: IAST,
-	staticContext: StaticContext
+	annotationContext: AnnotationContext
 ): SequenceType | undefined {
-	if (!staticContext) return undefined;
+	if (!annotationContext) return undefined;
 
 	const functionName = astHelper.getFirstChild(ast, 'functionName')[2];
 	const functionPrefix = astHelper.getFirstChild(ast, 'functionName')[1];
 	const functionArguments = astHelper.getChildren(astHelper.getFirstChild(ast, 'arguments'), '*');
 
-	const resolvedName = staticContext.resolveFunctionName(
+	const resolvedName = annotationContext.staticContext.resolveFunctionName(
 		{
 			localName: functionName as string,
 			prefix: functionPrefix['prefix'] as string,
@@ -22,7 +22,7 @@ export function annotateFunctionCall(
 
 	if (!resolvedName) return undefined;
 
-	const functionProps = staticContext.lookupFunction(
+	const functionProps = annotationContext.staticContext.lookupFunction(
 		resolvedName.namespaceURI,
 		resolvedName.localName,
 		functionArguments.length

--- a/src/typeInference/annotateFunctionCall.ts
+++ b/src/typeInference/annotateFunctionCall.ts
@@ -1,6 +1,6 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
-import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './AnnotatationContext';
 
 /**
  * Annotate the function calls by extracting the function info from the static context
@@ -12,17 +12,17 @@ import astHelper, { IAST } from '../parsing/astHelper';
  */
 export function annotateFunctionCall(
 	ast: IAST,
-	staticContext: StaticContext
+	annotationContext: AnnotationContext
 ): SequenceType | undefined {
 	// We need the context to lookup the function information
-	if (!staticContext) return undefined;
+	if (!annotationContext) return undefined;
 
 	const functionName = astHelper.getFirstChild(ast, 'functionName')[2];
 	const functionPrefix = astHelper.getFirstChild(ast, 'functionName')[1];
 	const functionArguments = astHelper.getChildren(astHelper.getFirstChild(ast, 'arguments'), '*');
 
 	// Lookup the namespace URI
-	const resolvedName = staticContext.resolveFunctionName(
+	const resolvedName = annotationContext.staticContext.resolveFunctionName(
 		{
 			localName: functionName as string,
 			prefix: functionPrefix['prefix'] as string,
@@ -33,7 +33,7 @@ export function annotateFunctionCall(
 	if (!resolvedName) return undefined;
 
 	// Lookup the function properties (return type)
-	const functionProps = staticContext.lookupFunction(
+	const functionProps = annotationContext.staticContext.lookupFunction(
 		resolvedName.namespaceURI,
 		resolvedName.localName,
 		functionArguments.length

--- a/src/typeInference/annotateFunctionCall.ts
+++ b/src/typeInference/annotateFunctionCall.ts
@@ -15,7 +15,7 @@ export function annotateFunctionCall(
 	annotationContext: AnnotationContext
 ): SequenceType | undefined {
 	// We need the context to lookup the function information
-	if (!annotationContext) return undefined;
+	if (!annotationContext || !annotationContext.staticContext) return undefined;
 
 	const functionName = astHelper.getFirstChild(ast, 'functionName')[2];
 	const functionPrefix = astHelper.getFirstChild(ast, 'functionName')[1];

--- a/src/typeInference/annotateNamedFunctionRef.ts
+++ b/src/typeInference/annotateNamedFunctionRef.ts
@@ -1,6 +1,6 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
-import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './AnnotatationContext';
 
 /**
  * Annotate named function references by extracting the function info from the static context
@@ -12,10 +12,10 @@ import astHelper, { IAST } from '../parsing/astHelper';
  */
 export function annotateNamedFunctionRef(
 	ast: IAST,
-	staticContext: StaticContext
+	annotationContext: AnnotationContext
 ): SequenceType | undefined {
 	// Can't find info about the function without the context.
-	if (!staticContext) return undefined;
+	if (!annotationContext || !annotationContext.staticContext) return undefined;
 
 	// Get qualified function name
 	const functionQName = astHelper.getQName(astHelper.getFirstChild(ast, 'functionName'));
@@ -29,7 +29,10 @@ export function annotateNamedFunctionRef(
 
 	// If there is no namespace URI, resolve the function name
 	if (!namespaceURI) {
-		const functionName = staticContext.resolveFunctionName({ localName, prefix }, arity);
+		const functionName = annotationContext.staticContext.resolveFunctionName(
+			{ localName, prefix },
+			arity
+		);
 
 		if (!functionName) {
 			return undefined;
@@ -40,7 +43,8 @@ export function annotateNamedFunctionRef(
 	}
 
 	// With all components there, look up the function properties
-	const functionProperties = staticContext.lookupFunction(namespaceURI, localName, arity) || null;
+	const functionProperties =
+		annotationContext.staticContext.lookupFunction(namespaceURI, localName, arity) || null;
 
 	// If there are no function properties, there is no type inference
 	if (!functionProperties) return undefined;


### PR DESCRIPTION

## Description

Introduces AnnotationContext and provides basic Flwor variable and full Flwor annotation.

Closes #53 

## Changes

1. Annotation Context is introduced to keep track of the scope information.
    - AnnotationContext contains the StaticContext as a class attribute
    - Stores different scopes and all variables within these scopes
    - Provide functions to push and pop the scope stack
    - Method to insert variables with variable name checks
2. Provide basic flwor annotation support
    - Switch statement that redirects to for, let, return operations
3. Provide LetClause annotation on the returnType
    - Stores the variable names and its type

## Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

## How Many Approvals?

* 3 Approvals (Bigger features that span multiple domains/releases to master)
