### PR TITLE
Add type annotation to sequenceExpr

### DIFF
--- a/src/expressions/operators/IntersectExcept.ts
+++ b/src/expressions/operators/IntersectExcept.ts
@@ -3,7 +3,7 @@ import { compareNodePositions, sortNodeValues } from '../dataTypes/documentOrder
 import ISequence from '../dataTypes/ISequence';
 import isSubtypeOf from '../dataTypes/isSubtypeOf';
 import sequenceFactory from '../dataTypes/sequenceFactory';
-import { ValueType } from '../dataTypes/Value';
+import { SequenceType, ValueType } from '../dataTypes/Value';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
 import { DONE_TOKEN, IterationHint, ready } from '../util/iterators';
 import arePointersEqual from './compares/arePointersEqual';
@@ -39,15 +39,26 @@ class IntersectExcept extends Expression {
 	private _expression1: Expression;
 	private _expression2: Expression;
 	private _intersectOrExcept: string;
-	constructor(intersectOrExcept: string, expression1: Expression, expression2: Expression) {
+	constructor(
+		intersectOrExcept: string,
+		expression1: Expression,
+		expression2: Expression,
+		type: SequenceType
+	) {
 		const maxSpecificity =
 			expression1.specificity.compareTo(expression2.specificity) > 0
 				? expression1.specificity
 				: expression2.specificity;
-		super(maxSpecificity, [expression1, expression2], {
-			canBeStaticallyEvaluated:
-				expression1.canBeStaticallyEvaluated && expression2.canBeStaticallyEvaluated,
-		});
+		super(
+			maxSpecificity,
+			[expression1, expression2],
+			{
+				canBeStaticallyEvaluated:
+					expression1.canBeStaticallyEvaluated && expression2.canBeStaticallyEvaluated,
+			},
+			false,
+			type
+		);
 
 		this._intersectOrExcept = intersectOrExcept;
 		this._expression1 = expression1;

--- a/src/expressions/operators/SequenceOperator.ts
+++ b/src/expressions/operators/SequenceOperator.ts
@@ -1,5 +1,6 @@
 import ISequence from '../dataTypes/ISequence';
 import sequenceFactory from '../dataTypes/sequenceFactory';
+import { SequenceType } from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
@@ -11,7 +12,8 @@ import concatSequences from '../util/concatSequences';
  * The Sequence selector evaluates its operands and returns them as a single sequence
  */
 class SequenceOperator extends PossiblyUpdatingExpression {
-	constructor(expressions: Expression[]) {
+	// TODO: make the type parameter NON-optional (made optional for not breaking too much code, while adding type annotation)
+	constructor(expressions: Expression[], type?: SequenceType) {
 		super(
 			expressions.reduce((specificity, selector) => {
 				return specificity.add(selector.specificity);
@@ -22,7 +24,8 @@ class SequenceOperator extends PossiblyUpdatingExpression {
 				canBeStaticallyEvaluated: expressions.every(
 					(selector) => selector.canBeStaticallyEvaluated
 				),
-			}
+			},
+			type
 		);
 	}
 

--- a/src/expressions/operators/Union.ts
+++ b/src/expressions/operators/Union.ts
@@ -1,7 +1,7 @@
 import { sortNodeValues } from '../dataTypes/documentOrderUtils';
 import isSubtypeOf from '../dataTypes/isSubtypeOf';
 import sequenceFactory from '../dataTypes/sequenceFactory';
-import { ValueType } from '../dataTypes/Value';
+import { SequenceType, ValueType } from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
@@ -16,18 +16,24 @@ import { mergeSortedSequences } from '../util/sortedSequenceUtils';
 class Union extends Expression {
 	private _subExpressions: Expression[];
 
-	constructor(expressions: Expression[]) {
+	constructor(expressions: Expression[], type: SequenceType) {
 		const maxSpecificity = expressions.reduce((maxSpecificitySoFar, expression) => {
 			if (maxSpecificitySoFar.compareTo(expression.specificity) > 0) {
 				return maxSpecificitySoFar;
 			}
 			return expression.specificity;
 		}, new Specificity({}));
-		super(maxSpecificity, expressions, {
-			canBeStaticallyEvaluated: expressions.every(
-				(expression) => expression.canBeStaticallyEvaluated
-			),
-		});
+		super(
+			maxSpecificity,
+			expressions,
+			{
+				canBeStaticallyEvaluated: expressions.every(
+					(expression) => expression.canBeStaticallyEvaluated
+				),
+			},
+			false,
+			type
+		);
 
 		this._subExpressions = expressions;
 	}

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -1033,6 +1033,7 @@ function stringConcatenateOp(ast: IAST, compilationOptions: CompilationOptions) 
 }
 
 function rangeSequenceExpr(ast: IAST, compilationOptions: CompilationOptions) {
+	const typeNode = astHelper.followPath(ast, ['type']);
 	const args = [
 		astHelper.getFirstChild(ast, 'startExpr')[1] as IAST,
 		astHelper.getFirstChild(ast, 'endExpr')[1] as IAST,
@@ -1049,7 +1050,8 @@ function rangeSequenceExpr(ast: IAST, compilationOptions: CompilationOptions) {
 
 	return new FunctionCall(
 		ref,
-		args.map((arg) => compile(arg, disallowUpdating(compilationOptions)))
+		args.map((arg) => compile(arg, disallowUpdating(compilationOptions))),
+		typeNode ? (typeNode[1] as SequenceType) : undefined
 	);
 }
 

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -1013,6 +1013,7 @@ function simpleMap(ast: IAST, compilationOptions: CompilationOptions) {
 }
 
 function stringConcatenateOp(ast: IAST, compilationOptions: CompilationOptions) {
+	const typeNode = astHelper.followPath(ast, ['type']);
 	const args = [
 		astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST,
 		astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST,
@@ -1026,7 +1027,8 @@ function stringConcatenateOp(ast: IAST, compilationOptions: CompilationOptions) 
 			},
 			args.length
 		),
-		args.map((arg) => compile(arg, disallowUpdating(compilationOptions)))
+		args.map((arg) => compile(arg, disallowUpdating(compilationOptions))),
+		typeNode ? (typeNode[1] as SequenceType) : undefined
 	);
 }
 

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -995,8 +995,11 @@ function sequence(ast: IAST, compilationOptions: CompilationOptions) {
 	if (childExpressions.length === 1) {
 		return childExpressions[0];
 	}
+
+	const typeNode = astHelper.followPath(ast, ['type']);
 	return new SequenceOperator(
-		astHelper.getChildren(ast, '*').map((arg) => compile(arg, compilationOptions))
+		astHelper.getChildren(ast, '*').map((arg) => compile(arg, compilationOptions)),
+		typeNode ? (typeNode[1] as SequenceType) : undefined
 	);
 }
 

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -1091,19 +1091,24 @@ function unaryMinus(
 }
 
 function unionOp(ast: IAST, compilationOptions: CompilationOptions) {
-	return new Union([
-		compile(
-			astHelper.followPath(ast, ['firstOperand', '*']),
-			disallowUpdating(compilationOptions)
-		),
-		compile(
-			astHelper.followPath(ast, ['secondOperand', '*']),
-			disallowUpdating(compilationOptions)
-		),
-	]);
+	const typeNode = astHelper.followPath(ast, ['type']);
+	return new Union(
+		[
+			compile(
+				astHelper.followPath(ast, ['firstOperand', '*']),
+				disallowUpdating(compilationOptions)
+			),
+			compile(
+				astHelper.followPath(ast, ['secondOperand', '*']),
+				disallowUpdating(compilationOptions)
+			),
+		],
+		typeNode ? (typeNode[1] as SequenceType) : undefined
+	);
 }
 
 function intersectExcept(ast: IAST, compilationOptions: CompilationOptions) {
+	const typeNode = astHelper.followPath(ast, ['type']);
 	return new IntersectExcept(
 		ast[0],
 		compile(
@@ -1113,7 +1118,8 @@ function intersectExcept(ast: IAST, compilationOptions: CompilationOptions) {
 		compile(
 			astHelper.followPath(ast, ['secondOperand', '*']),
 			disallowUpdating(compilationOptions)
-		)
+		),
+		typeNode ? (typeNode[1] as SequenceType) : undefined
 	);
 }
 

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -10,6 +10,7 @@ import {
 } from './annotateCompareOperator';
 import { annotateFunctionCall } from './annotateFunctionCall';
 import { annotateLogicalOperator } from './annotateLogicalOperator';
+import { annotateSequenceOperator } from './annotateSequenceOperator';
 import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
 
 /**
@@ -81,6 +82,12 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 			annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, staticContext);
 			annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, staticContext);
 			return annotateLogicalOperator(ast);
+
+		// Sequences
+		case 'sequenceExpr':
+			const children = astHelper.getChildren(ast, '*');
+			children.map((arg) => annotate(arg, staticContext));
+			return annotateSequenceOperator(ast, children.length);
 
 		// Comparison operators
 		case 'equalOp':

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -115,12 +115,9 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 
 		// Range operator
 		case 'rangeSequenceExpr':
-			const start = annotate(
-				astHelper.getFirstChild(ast, 'startExpr')[1] as IAST,
-				staticContext
-			);
-			const end = annotate(astHelper.getFirstChild(ast, 'endExpr')[1] as IAST, staticContext);
-			return annotateRangeSequenceOperator(ast, start, end);
+			annotate(astHelper.getFirstChild(ast, 'startExpr')[1] as IAST, staticContext);
+			annotate(astHelper.getFirstChild(ast, 'endExpr')[1] as IAST, staticContext);
+			return annotateRangeSequenceOperator(ast);
 
 		// Comparison operators
 		case 'equalOp':

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -10,6 +10,7 @@ import {
 } from './annotateCompareOperator';
 import { annotateFunctionCall } from './annotateFunctionCall';
 import { annotateLogicalOperator } from './annotateLogicalOperator';
+import { annotateRangeSequenceOperator } from './annotateRangeSequenceOperator';
 import { annotateSequenceOperator } from './annotateSequenceOperator';
 import { annotateSetOperator } from './annotateSetOperators';
 import { annotateStringConcatenateOperator } from './annotateStringConcatenateOperator';
@@ -111,6 +112,15 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 			annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, staticContext);
 			annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, staticContext);
 			return annotateStringConcatenateOperator(ast);
+
+		// Range operator
+		case 'rangeSequenceExpr':
+			const start = annotate(
+				astHelper.getFirstChild(ast, 'startExpr')[1] as IAST,
+				staticContext
+			);
+			const end = annotate(astHelper.getFirstChild(ast, 'endExpr')[1] as IAST, staticContext);
+			return annotateRangeSequenceOperator(ast, start, end);
 
 		// Comparison operators
 		case 'equalOp':

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -11,6 +11,7 @@ import {
 import { annotateFunctionCall } from './annotateFunctionCall';
 import { annotateLogicalOperator } from './annotateLogicalOperator';
 import { annotateSequenceOperator } from './annotateSequenceOperator';
+import { annotateSetOperator } from './annotateSetOperators';
 import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
 
 /**
@@ -58,6 +59,7 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 				staticContext
 			);
 			return annotateUnaryPlus(ast, plusVal);
+
 		// Binary arithmetic operators
 		case 'addOp':
 		case 'subtractOp':
@@ -88,6 +90,20 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 			const children = astHelper.getChildren(ast, '*');
 			children.map((arg) => annotate(arg, staticContext));
 			return annotateSequenceOperator(ast, children.length);
+
+		// Set operations (union, intersect, except)
+		case 'unionOp':
+		case 'intersectOp':
+		case 'exceptOp':
+			const l = annotate(
+				astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST,
+				staticContext
+			);
+			const r = annotate(
+				astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST,
+				staticContext
+			);
+			return annotateSetOperator(ast, l, r);
 
 		// Comparison operators
 		case 'equalOp':

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -12,6 +12,7 @@ import { annotateFunctionCall } from './annotateFunctionCall';
 import { annotateLogicalOperator } from './annotateLogicalOperator';
 import { annotateSequenceOperator } from './annotateSequenceOperator';
 import { annotateSetOperator } from './annotateSetOperators';
+import { annotateStringConcatenateOperator } from './annotateStringConcatenateOperator';
 import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
 
 /**
@@ -104,6 +105,12 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 				staticContext
 			);
 			return annotateSetOperator(ast, l, r);
+
+		// String concatentation
+		case 'stringConcatenateOp':
+			annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, staticContext);
+			annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, staticContext);
+			return annotateStringConcatenateOperator(ast);
 
 		// Comparison operators
 		case 'equalOp':

--- a/src/typeInference/annotateBinaryOperator.ts
+++ b/src/typeInference/annotateBinaryOperator.ts
@@ -25,11 +25,6 @@ export function annotateBinOp(
 		return undefined;
 	}
 
-	// If the multiplicities don't match, we can't add them
-	if (left.mult !== right.mult) {
-		throw new Error("Multiplicities in binary addition operator don't match");
-	}
-
 	const funcData = getBinaryPrefabOperator(left.type, right.type, operator);
 
 	if (funcData) {

--- a/src/typeInference/annotateRangeSequenceOperator.ts
+++ b/src/typeInference/annotateRangeSequenceOperator.ts
@@ -1,16 +1,12 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
 
-export function annotateRangeSequenceOperator(
-	ast: IAST,
-	start: SequenceType,
-	end: SequenceType
-): SequenceType {
-	if (!start || !end) return undefined;
-
-	// TODO: add check to see if start is an integer and end is an integer and start > end --> return undefined
-	// TODO: add check to see if start is an integer and end is an integer and start == end --> return XSINTEGER
-
+/**
+ * Inserts an integer sequence into the AST for the rangeSequenceExpr node.
+ * @param ast the AST to be annotated.
+ * @returns an integer sequence.
+ */
+export function annotateRangeSequenceOperator(ast: IAST): SequenceType {
 	const seqType = {
 		type: ValueType.XSINTEGER,
 		mult: SequenceMultiplicity.ONE_OR_MORE,

--- a/src/typeInference/annotateRangeSequenceOperator.ts
+++ b/src/typeInference/annotateRangeSequenceOperator.ts
@@ -1,0 +1,22 @@
+import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import astHelper, { IAST } from '../parsing/astHelper';
+
+export function annotateRangeSequenceOperator(
+	ast: IAST,
+	start: SequenceType,
+	end: SequenceType
+): SequenceType {
+	if (!start || !end) return undefined;
+
+	// TODO: add check to see if start is an integer and end is an integer and start > end --> return undefined
+	// TODO: add check to see if start is an integer and end is an integer and start == end --> return XSINTEGER
+
+	const seqType = {
+		type: ValueType.XSINTEGER,
+		mult: SequenceMultiplicity.ONE_OR_MORE,
+	};
+
+	astHelper.insertAttribute(ast, 'type', seqType);
+
+	return seqType;
+}

--- a/src/typeInference/annotateSequenceOperator.ts
+++ b/src/typeInference/annotateSequenceOperator.ts
@@ -1,0 +1,22 @@
+import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import astHelper, { IAST } from '../parsing/astHelper';
+
+/**
+ * Inserts an item* type to the AST, as sequence operator can contain multiple different ITEM types.
+ * The actual types are stores in the children nodes.
+ * @param ast the AST to be annotated.
+ * @returns `SequenceType` of type ITEM with multiplicity of `ZERO_OR_MORE` or undefined in case we have an empty sequence.
+ */
+export function annotateSequenceOperator(ast: IAST, length: number): SequenceType {
+	if (length === 0) {
+		return undefined;
+	}
+	const seqType = {
+		type: ValueType.ITEM,
+		mult: SequenceMultiplicity.ZERO_OR_MORE,
+	};
+
+	astHelper.insertAttribute(ast, 'type', seqType);
+
+	return seqType;
+}

--- a/src/typeInference/annotateSetOperators.ts
+++ b/src/typeInference/annotateSetOperators.ts
@@ -1,0 +1,52 @@
+import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import astHelper, { IAST } from '../parsing/astHelper';
+
+export function annotateSetOperator(
+	ast: IAST,
+	left: SequenceType,
+	right: SequenceType
+): SequenceType | undefined {
+	if (!left || !right) return undefined;
+	if (left.type !== ValueType.NODE || right.type !== ValueType.NODE) {
+		return undefined;
+	}
+
+	switch (ast[0]) {
+		case 'unionOp':
+			return annotateUnionOperator(ast);
+		case 'intersectOp':
+			return annotateIntersectOperator(ast);
+		case 'exceptOp':
+			return annotateExceptOperator(ast);
+	}
+}
+
+function annotateUnionOperator(ast: IAST): SequenceType {
+	const seqType = {
+		type: ValueType.NODE,
+		mult: SequenceMultiplicity.ZERO_OR_MORE,
+	};
+
+	astHelper.insertAttribute(ast, 'type', seqType);
+	return seqType;
+}
+
+function annotateIntersectOperator(ast: IAST): SequenceType {
+	const seqType = {
+		type: ValueType.NODE,
+		mult: SequenceMultiplicity.ZERO_OR_MORE,
+	};
+
+	astHelper.insertAttribute(ast, 'type', seqType);
+	return seqType;
+}
+
+function annotateExceptOperator(ast: IAST): SequenceType {
+	const seqType = {
+		type: ValueType.NODE,
+		mult: SequenceMultiplicity.ZERO_OR_MORE,
+	};
+
+	astHelper.insertAttribute(ast, 'type', seqType);
+	return seqType;
+}

--- a/src/typeInference/annotateSetOperators.ts
+++ b/src/typeInference/annotateSetOperators.ts
@@ -1,6 +1,14 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
 
+/**
+ * Annotates the union, intersect and except operators with a sequence of nodes.
+ * @param ast the AST to be annotated.
+ * @param left the first sequence of nodes.
+ * @param right the second sequence of nodes.
+ * @returns undefined if either left or right is null of if one of them is not a node.
+ * Or it calls the union, intercept or except functions separately.
+ */
 export function annotateSetOperator(
 	ast: IAST,
 	left: SequenceType,

--- a/src/typeInference/annotateStringConcatenateOperator.ts
+++ b/src/typeInference/annotateStringConcatenateOperator.ts
@@ -1,0 +1,12 @@
+import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import astHelper, { IAST } from '../parsing/astHelper';
+
+export function annotateStringConcatenateOperator(ast: IAST): SequenceType | undefined {
+	const seqType = {
+		type: ValueType.XSSTRING,
+		mult: SequenceMultiplicity.EXACTLY_ONE,
+	};
+
+	astHelper.insertAttribute(ast, 'type', seqType);
+	return seqType;
+}


### PR DESCRIPTION
# Description

Add type annotation to a few other AST nodes.

## Changes:
* Add type annotation to sequenceExpr.
* Add type annotation to set operators.
    - unionOp
    - interceptOp
    - exceptOp
* Add type annotation to stringConcatenateOp
* Add type annotation to rangeSequenceExpr

# Deletes Source Branch?

No:     Work is (partially) done, but more work will be done on the source branch.

## How Many Approvals?

* 2 Approvals (Normal features and bugs)