### PR TITLE
58 add type annotation to typeswitch expr

### DIFF
--- a/src/expressions/xquery/TypeSwitchExpression.ts
+++ b/src/expressions/xquery/TypeSwitchExpression.ts
@@ -1,9 +1,10 @@
 import ISequence from '../dataTypes/ISequence';
 import sequenceFactory from '../dataTypes/sequenceFactory';
+import { SequenceType } from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
-import PossiblyUpdatingExpression from '../PossiblyUpdatingExpression';
+import PossiblyUpdatingExpression, { SequenceCallbacks } from '../PossiblyUpdatingExpression';
 import Specificity from '../Specificity';
 import StaticContext from '../StaticContext';
 import { errXUST0001 } from '../xquery-update/XQueryUpdateFacilityErrors';
@@ -26,7 +27,8 @@ class TypeSwitchExpression extends PossiblyUpdatingExpression {
 	constructor(
 		argExpression: Expression,
 		caseClauses: TypeSwitchCaseClause[],
-		defaultExpression: PossiblyUpdatingExpression
+		defaultExpression: PossiblyUpdatingExpression,
+		type: SequenceType
 	) {
 		const specificity = new Specificity({});
 		super(
@@ -45,7 +47,8 @@ class TypeSwitchExpression extends PossiblyUpdatingExpression {
 				peer: false,
 				resultOrder: RESULT_ORDERINGS.UNSORTED,
 				subtree: false,
-			}
+			},
+			type
 		);
 		this._argExpression = argExpression;
 		this._amountOfCases = caseClauses.length;

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -1,3 +1,4 @@
+import { isUndefined } from 'util';
 import CurlyArrayConstructor from '../expressions/arrays/CurlyArrayConstructor';
 import SquareArrayConstructor from '../expressions/arrays/SquareArrayConstructor';
 import AncestorAxis from '../expressions/axes/AncestorAxis';
@@ -1423,6 +1424,8 @@ function typeswitchExpr(ast: IAST, compilationOptions: CompilationOptions) {
 		throw new Error('XPST0003: Use of XQuery functionality is not allowed in XPath context');
 	}
 
+	const typeNode = astHelper.followPath(ast, ['type']);
+
 	const argExpr = compile(
 		astHelper.getFirstChild(astHelper.getFirstChild(ast, 'argExpr'), '*'),
 		compilationOptions
@@ -1471,7 +1474,12 @@ function typeswitchExpr(ast: IAST, compilationOptions: CompilationOptions) {
 		compilationOptions
 	) as PossiblyUpdatingExpression;
 
-	return new TypeSwitchExpression(argExpr, caseClauseExpressions, defaultExpression);
+	return new TypeSwitchExpression(
+		argExpr,
+		caseClauseExpressions,
+		defaultExpression,
+		typeNode ? (typeNode[1] as SequenceType) : undefined
+	);
 }
 
 export default function (xPathAst: IAST, compilationOptions: CompilationOptions): Expression {

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -1,4 +1,3 @@
-import { isUndefined } from 'util';
 import CurlyArrayConstructor from '../expressions/arrays/CurlyArrayConstructor';
 import SquareArrayConstructor from '../expressions/arrays/SquareArrayConstructor';
 import AncestorAxis from '../expressions/axes/AncestorAxis';

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -185,6 +185,16 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 			return annotateCastOperator(ast);
 		case 'castableExpr':
 			return annotateCastableOperator(ast);
+		case 'typeSwitchExpr':
+			const arg = annotate(astHelper.getFirstChild(ast, 'argExpr') as IAST, staticContext);
+			const clauses = (astHelper.getChildren(
+				ast,
+				'typeswitchExprCaseClause'
+			) as IAST[]).map((a) => annotate(a, staticContext));
+			const defaultCase = annotate(
+				astHelper.getFirstChild(ast, 'typeSwitchExprDefaultClause') as IAST,
+				staticContext
+			);
 		default:
 			// Current node cannot be annotated, but maybe deeper ones can.
 			for (let i = 1; i < ast.length; i++) {

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -14,6 +14,7 @@ import { annotateRangeSequenceOperator } from './annotateRangeSequenceOperator';
 import { annotateSequenceOperator } from './annotateSequenceOperator';
 import { annotateSetOperator } from './annotateSetOperators';
 import { annotateStringConcatenateOperator } from './annotateStringConcatenateOperator';
+import { annotateTypeSwitchOperator } from './annotateTypeSwitchOperator';
 import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
 
 /**
@@ -90,7 +91,7 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 		// Sequences
 		case 'sequenceExpr':
 			const children = astHelper.getChildren(ast, '*');
-			children.map((arg) => annotate(arg, staticContext));
+			children.map((a) => annotate(a, staticContext));
 			return annotateSequenceOperator(ast, children.length);
 
 		// Set operations (union, intersect, except)
@@ -187,14 +188,14 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 			return annotateCastableOperator(ast);
 		case 'typeSwitchExpr':
 			const arg = annotate(astHelper.getFirstChild(ast, 'argExpr') as IAST, staticContext);
-			const clauses = (astHelper.getChildren(
-				ast,
-				'typeswitchExprCaseClause'
-			) as IAST[]).map((a) => annotate(a, staticContext));
+			const clauses = astHelper
+				.getChildren(ast, 'typeswitchExprCaseClause')
+				.map((a) => annotate(a, staticContext));
 			const defaultCase = annotate(
 				astHelper.getFirstChild(ast, 'typeSwitchExprDefaultClause') as IAST,
 				staticContext
 			);
+			annotateTypeSwitchOperator(ast);
 		default:
 			// Current node cannot be annotated, but maybe deeper ones can.
 			for (let i = 1; i < ast.length; i++) {

--- a/src/typeInference/annotateTypeSwitchOperator.ts
+++ b/src/typeInference/annotateTypeSwitchOperator.ts
@@ -1,0 +1,7 @@
+import { SequenceType } from '../expressions/dataTypes/Value';
+import { IAST } from '../parsing/astHelper';
+
+// TODO: Implement this function, the docs don't mention it so we don't know the return types.
+function annotateTypeSwitchOperator(ast: IAST): SequenceType {
+	return undefined;
+}

--- a/src/typeInference/annotateTypeSwitchOperator.ts
+++ b/src/typeInference/annotateTypeSwitchOperator.ts
@@ -2,6 +2,6 @@ import { SequenceType } from '../expressions/dataTypes/Value';
 import { IAST } from '../parsing/astHelper';
 
 // TODO: Implement this function, the docs don't mention it so we don't know the return types.
-function annotateTypeSwitchOperator(ast: IAST): SequenceType {
+export function annotateTypeSwitchOperator(ast: IAST): SequenceType {
 	return undefined;
 }


### PR DESCRIPTION
# Pull Request

## Description

Added the ability to use the annotated ast for the typeswitch.

## Changes

1. created annotate Typeswitch file

## Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

## How Many Approvals?

* 1 Approval (Small bugs/hot-fixes)