### PR TITLE
58 add type annotation to dynamic function invocation expr

### DIFF
--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -654,6 +654,7 @@ function functionCall(
 }
 
 function arrowExpr(ast: IAST, compilationOptions: CompilationOptions) {
+	const typeNode = astHelper.followPath(ast, ['type']);
 	const argExpr = astHelper.followPath(ast, ['argExpr', '*']);
 
 	// Each part an EQName, expression, or arguments passed to the previous part
@@ -677,7 +678,7 @@ function arrowExpr(ast: IAST, compilationOptions: CompilationOptions) {
 			parts[i][0] === 'EQName'
 				? new NamedFunctionRef(astHelper.getQName(parts[i]), args.length)
 				: compile(parts[i], disallowUpdating(compilationOptions));
-		args = [new FunctionCall(func, args)];
+		args = [new FunctionCall(func, args, typeNode ? (typeNode[1] as SequenceType) : undefined)];
 	}
 	return args[0];
 }

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -684,7 +684,7 @@ function arrowExpr(ast: IAST, compilationOptions: CompilationOptions) {
 
 function dynamicFunctionInvocationExpr(ast: IAST, compilationOptions: CompilationOptions) {
 	const functionItemContent = astHelper.followPath(ast, ['functionItem', '*']);
-
+	const retType: IAST = astHelper.followPath(ast, ['type']);
 	const argumentsAst = astHelper.getFirstChild(ast, 'arguments');
 	let args = [];
 	if (argumentsAst) {
@@ -694,7 +694,11 @@ function dynamicFunctionInvocationExpr(ast: IAST, compilationOptions: Compilatio
 		);
 	}
 
-	return new FunctionCall(compile(functionItemContent, compilationOptions), args);
+	return new FunctionCall(
+		compile(functionItemContent, compilationOptions),
+		args,
+		retType ? (retType[1] as SequenceType) : undefined
+	);
 }
 
 function namedFunctionRef(ast: IAST, _compilationOptions: CompilationOptions) {

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -9,6 +9,7 @@ import {
 	annotateValueCompare,
 } from './annotateCompareOperator';
 import { annotateContextItemExpr } from './annotateContextItemExpr';
+import { annotateDynamicFunctionInvocationExpr } from './annotateDynamicFunctionInvocationExpr';
 import { annotateFunctionCall } from './annotateFunctionCall';
 import { annotateInstanceOfExpr } from './annotateInstanceOfExpr';
 import { annotateLogicalOperator } from './annotateLogicalOperator';
@@ -205,7 +206,16 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 		// Functions
 		case 'functionCallExpr':
 			return annotateFunctionCall(ast, staticContext);
-
+		case 'dynamicFunctionInvocationExpr':
+			const functionItem: SequenceType = annotate(
+				astHelper.followPath(ast, ['functionItem', '*']),
+				staticContext
+			);
+			const args: SequenceType = annotate(
+				astHelper.getFirstChild(ast, 'arguments'),
+				staticContext
+			);
+			return annotateDynamicFunctionInvocationExpr(ast, staticContext, functionItem, args);
 		// Casting
 		case 'castExpr':
 			return annotateCastOperator(ast);

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -1,6 +1,7 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { annotateArrowExpr } from './annotateArrowExpr';
 import { annotateBinOp } from './annotateBinaryOperator';
 import { annotateCastableOperator, annotateCastOperator } from './annotateCastOperators';
 import {
@@ -205,6 +206,8 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 		// Functions
 		case 'functionCallExpr':
 			return annotateFunctionCall(ast, staticContext);
+		case 'arrowExpr':
+			return annotateArrowExpr(ast, staticContext);
 
 		// Casting
 		case 'castExpr':

--- a/src/typeInference/annotateArrowExpr.ts
+++ b/src/typeInference/annotateArrowExpr.ts
@@ -1,5 +1,5 @@
-import StaticContext from '../expressions/StaticContext';
 import { SequenceType } from '../expressions/dataTypes/Value';
+import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
 
 /**
@@ -14,32 +14,31 @@ export function annotateArrowExpr(
 	ast: IAST,
 	staticContext: StaticContext
 ): SequenceType | undefined {
-    // We need the context to lookup the function information
-    if (!staticContext) return undefined;
+	// We need the context to lookup the function information
+	if (!staticContext) return undefined;
 
-    const func = astHelper.getFirstChild(ast, 'EQName');
+	const func = astHelper.getFirstChild(ast, 'EQName');
 
-    // There may be no name for the function
-    if (!func) {
-        return undefined;
-    }
+	// There may be no name for the function
+	if (!func) {
+		return undefined;
+	}
 
-    // Sometimes there is no prefix given, hence we need to check for that case and give an empty prefix
-    let functionName;
-    let functionPrefix;
-    if (func.length === 3) {
-        functionName = func[2];
-        functionPrefix = func[1];
-    }
-    else {
-        functionName = func[1];
-        functionPrefix = '';
-    }
+	// Sometimes there is no prefix given, hence we need to check for that case and give an empty prefix
+	let functionName;
+	let functionPrefix;
+	if (func.length === 3) {
+		functionName = func[2];
+		functionPrefix = func[1];
+	} else {
+		functionName = func[1];
+		functionPrefix = '';
+	}
 
-    const functionArguments = astHelper.getChildren(astHelper.getFirstChild(ast, 'arguments'), '*');
+	const functionArguments = astHelper.getChildren(astHelper.getFirstChild(ast, 'arguments'), '*');
 
-    // Lookup the namespace URI
-    const resolvedName = staticContext.resolveFunctionName(
+	// Lookup the namespace URI
+	const resolvedName = staticContext.resolveFunctionName(
 		{
 			localName: functionName as string,
 			prefix: functionPrefix['prefix'] as string,
@@ -47,16 +46,16 @@ export function annotateArrowExpr(
 		functionArguments.length
 	);
 
-    if (!resolvedName) return undefined;
+	if (!resolvedName) return undefined;
 
-    // Lookup the function properties (return type)
-    const functionProps = staticContext.lookupFunction(
+	// Lookup the function properties (return type)
+	const functionProps = staticContext.lookupFunction(
 		resolvedName.namespaceURI,
 		resolvedName.localName,
 		functionArguments.length
 	);
 
-    if (!functionProps) return undefined;
+	if (!functionProps) return undefined;
 
 	astHelper.insertAttribute(ast, 'type', functionProps.returnType);
 	return functionProps.returnType;

--- a/src/typeInference/annotateArrowExpr.ts
+++ b/src/typeInference/annotateArrowExpr.ts
@@ -1,0 +1,63 @@
+import StaticContext from '../expressions/StaticContext';
+import { SequenceType } from '../expressions/dataTypes/Value';
+import astHelper, { IAST } from '../parsing/astHelper';
+
+/**
+ * Annotate the arrowExpr by extracting the function info from the static context
+ * and inserting the return type to the AST as new attribute `type`.
+ *
+ * @param ast the AST to be annotated.
+ * @param staticContext from witch the function info is extracted.
+ * @returns the inferred type or `undefined` when function properties cannot be inferred.
+ */
+export function annotateArrowExpr(
+	ast: IAST,
+	staticContext: StaticContext
+): SequenceType | undefined {
+    // We need the context to lookup the function information
+    if (!staticContext) return undefined;
+
+    const func = astHelper.getFirstChild(ast, 'EQName');
+
+    // There may be no name for the function
+    if (!func) {
+        return undefined;
+    }
+
+    // Sometimes there is no prefix given, hence we need to check for that case and give an empty prefix
+    let functionName;
+    let functionPrefix;
+    if (func.length === 3) {
+        functionName = func[2];
+        functionPrefix = func[1];
+    }
+    else {
+        functionName = func[1];
+        functionPrefix = '';
+    }
+
+    const functionArguments = astHelper.getChildren(astHelper.getFirstChild(ast, 'arguments'), '*');
+
+    // Lookup the namespace URI
+    const resolvedName = staticContext.resolveFunctionName(
+		{
+			localName: functionName as string,
+			prefix: functionPrefix['prefix'] as string,
+		},
+		functionArguments.length
+	);
+
+    if (!resolvedName) return undefined;
+
+    // Lookup the function properties (return type)
+    const functionProps = staticContext.lookupFunction(
+		resolvedName.namespaceURI,
+		resolvedName.localName,
+		functionArguments.length
+	);
+
+    if (!functionProps) return undefined;
+
+	astHelper.insertAttribute(ast, 'type', functionProps.returnType);
+	return functionProps.returnType;
+}

--- a/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
+++ b/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
@@ -1,0 +1,22 @@
+import { SequenceType } from '../expressions/dataTypes/Value';
+import StaticContext from '../expressions/StaticContext';
+import { IAST } from '../parsing/astHelper';
+
+/**
+ * At this moment there is no way to infre the return type of this function as
+ * this would require the query to be executed. Therefore, the it would return undefined.
+ *
+ * @param ast The ast we need to check the type of.
+ * @param staticContext The context in which it is evaluated.
+ * @param functionItem the function body itself.
+ * @param args the arguments with which the function is called.
+ * @returns The type of the ast.
+ */
+export function annotateDynamicFunctionInvocationExpr(
+	ast: IAST,
+	staticContext: StaticContext,
+	functionItem: SequenceType,
+	args: SequenceType
+): SequenceType {
+	return undefined;
+}


### PR DESCRIPTION
# Pull Request

## Description

Add the type annotation to dynamic Function Invocation Expr. As we don't know the type of this expression without evaluating it we just typeCheck the arguments and functionbody.

## Changes

1. Added type annotation to args and body of the dynamic function Invocation Expr.
2. Added template to add the type info later on.

## Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

## How Many Approvals?

* 2 Approvals (Normal features and bugs)