### PR TITLE
Added type annotation to ifThenElseExpr

### DIFF
--- a/src/expressions/conditional/IfExpression.ts
+++ b/src/expressions/conditional/IfExpression.ts
@@ -1,6 +1,6 @@
 import ISequence from '../dataTypes/ISequence';
 import sequenceFactory from '../dataTypes/sequenceFactory';
-import Value from '../dataTypes/Value';
+import Value, { SequenceType } from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
@@ -15,23 +15,30 @@ class IfExpression extends PossiblyUpdatingExpression {
 	constructor(
 		testExpression: Expression,
 		thenExpression: PossiblyUpdatingExpression,
-		elseExpression: PossiblyUpdatingExpression
+		elseExpression: PossiblyUpdatingExpression,
+		type: SequenceType
 	) {
 		const specificity = testExpression.specificity
 			.add(thenExpression.specificity)
 			.add(elseExpression.specificity);
-		super(specificity, [testExpression, thenExpression, elseExpression], {
-			canBeStaticallyEvaluated:
-				testExpression.canBeStaticallyEvaluated &&
-				thenExpression.canBeStaticallyEvaluated &&
-				elseExpression.canBeStaticallyEvaluated,
-			peer: thenExpression.peer === elseExpression.peer && thenExpression.peer,
-			resultOrder:
-				thenExpression.expectedResultOrder === elseExpression.expectedResultOrder
-					? thenExpression.expectedResultOrder
-					: RESULT_ORDERINGS.UNSORTED,
-			subtree: thenExpression.subtree === elseExpression.subtree && thenExpression.subtree,
-		});
+		super(
+			specificity,
+			[testExpression, thenExpression, elseExpression],
+			{
+				canBeStaticallyEvaluated:
+					testExpression.canBeStaticallyEvaluated &&
+					thenExpression.canBeStaticallyEvaluated &&
+					elseExpression.canBeStaticallyEvaluated,
+				peer: thenExpression.peer === elseExpression.peer && thenExpression.peer,
+				resultOrder:
+					thenExpression.expectedResultOrder === elseExpression.expectedResultOrder
+						? thenExpression.expectedResultOrder
+						: RESULT_ORDERINGS.UNSORTED,
+				subtree:
+					thenExpression.subtree === elseExpression.subtree && thenExpression.subtree,
+			},
+			type
+		);
 
 		this._testExpression = testExpression;
 	}

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -460,6 +460,7 @@ function compare(ast: IAST, compilationOptions: CompilationOptions) {
 }
 
 function IfThenElseExpr(ast: IAST, compilationOptions: CompilationOptions) {
+	const retType = astHelper.getAttribute(ast, 'type');
 	return new IfExpression(
 		compile(
 			astHelper.getFirstChild(astHelper.getFirstChild(ast, 'ifClause'), '*'),
@@ -472,7 +473,8 @@ function IfThenElseExpr(ast: IAST, compilationOptions: CompilationOptions) {
 		compile(
 			astHelper.getFirstChild(astHelper.getFirstChild(ast, 'elseClause'), '*'),
 			compilationOptions
-		) as PossiblyUpdatingExpression
+		) as PossiblyUpdatingExpression,
+		retType ? (retType[1] as SequenceType) : undefined
 	);
 }
 

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -13,6 +13,7 @@ import {
 import { annotateContextItemExpr } from './annotateContextItemExpr';
 import { annotateDynamicFunctionInvocationExpr } from './annotateDynamicFunctionInvocationExpr';
 import { annotateFunctionCall } from './annotateFunctionCall';
+import { annotateIfThenElseExpr } from './annotateIfThenElseExpr';
 import { annotateInstanceOfExpr } from './annotateInstanceOfExpr';
 import { annotateLogicalOperator } from './annotateLogicalOperator';
 import { annotateMapConstructor } from './annotateMapConstructor';
@@ -178,6 +179,7 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 				astHelper.getFirstChild(astHelper.getFirstChild(ast, 'elseClause'), '*'),
 				staticContext
 			);
+			return annotateIfThenElseExpr(ast, thenClause, elseClause);
 		}
 		case 'instanceOfExpr': {
 			annotate(astHelper.getFirstChild(ast, 'argExpr'), staticContext);

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -165,7 +165,20 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 		// Context Item
 		case 'contextItemExpr':
 			return annotateContextItemExpr(ast);
-
+		case 'ifThenElseExpr': {
+			const ifClause = annotate(
+				astHelper.getFirstChild(astHelper.getFirstChild(ast, 'ifClause'), '*'),
+				staticContext
+			);
+			const thenClause = annotate(
+				astHelper.getFirstChild(astHelper.getFirstChild(ast, 'thenClause'), '*'),
+				staticContext
+			);
+			const elseClause = annotate(
+				astHelper.getFirstChild(astHelper.getFirstChild(ast, 'elseClause'), '*'),
+				staticContext
+			);
+		}
 		case 'instanceOfExpr': {
 			annotate(astHelper.getFirstChild(ast, 'argExpr'), staticContext);
 			annotate(astHelper.getFirstChild(ast, 'sequenceType'), staticContext);

--- a/src/typeInference/annotateIfThenElseExpr.ts
+++ b/src/typeInference/annotateIfThenElseExpr.ts
@@ -1,0 +1,12 @@
+import { SequenceType } from '../expressions/dataTypes/Value';
+import { IAST } from '../parsing/astHelper';
+
+export function annotateIfThenElseExpr(
+	ast: IAST,
+	ifClause: SequenceType,
+	elseClause: SequenceType,
+	thenClause: SequenceType
+): SequenceType {
+	if (elseClause === thenClause) return elseClause;
+	else return undefined;
+}

--- a/src/typeInference/annotateIfThenElseExpr.ts
+++ b/src/typeInference/annotateIfThenElseExpr.ts
@@ -1,12 +1,17 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
-import { IAST } from '../parsing/astHelper';
+import astHelper, { IAST } from '../parsing/astHelper';
 
 export function annotateIfThenElseExpr(
 	ast: IAST,
-	ifClause: SequenceType,
 	elseClause: SequenceType,
 	thenClause: SequenceType
 ): SequenceType {
-	if (elseClause === thenClause) return elseClause;
-	else return undefined;
+	if (!elseClause || !thenClause) {
+		return undefined;
+	}
+	if (elseClause.type === thenClause.type && elseClause.mult === thenClause.mult) {
+		astHelper.insertAttribute(ast, 'type', elseClause);
+		return elseClause;
+	}
+	return undefined;
 }

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -10,7 +10,11 @@ function assertValueType(expression: string, expectedType: ValueType) {
 
 	const queryBody = astHelper.followPath(ast, ['mainModule', 'queryBody']);
 	const resultType = astHelper.getAttribute(queryBody[1] as IAST, 'type') as SequenceType;
-	chai.assert.deepEqual(resultType.type, expectedType);
+	if (!resultType) {
+		chai.assert.isTrue(!expectedType);
+	} else {
+		chai.assert.deepEqual(resultType.type, expectedType);
+	}
 }
 
 describe('Annotating constants', () => {
@@ -63,4 +67,10 @@ describe('Annotating cast expressions', () => {
 	it('simple cast expression', () => assertValueType('5 cast as xs:double', ValueType.XSDOUBLE));
 	it('unknown child cast expression', () =>
 		assertValueType('$x cast as xs:integer', ValueType.XSINTEGER));
+});
+
+describe('Annotating ifThenElse expressions', () => {
+	it('ifThenElse type is known', () =>
+		assertValueType('if (3) then 3 else 5', ValueType.XSINTEGER));
+	it('ifThenElse type is not known', () => assertValueType('if (3) then "hello" else 5', null));
 });


### PR DESCRIPTION
# Pull Request

## Description

Added type annotation to ifThenElseExpr. We return the type when we are sure of it, the only case where this is is if both the then en elseClause have the same type.

Closes part of #58

## Changes

1. Added type annotation to ifThenElseExpr
2. Added the shortcut

## Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

## How Many Approvals?

* 2 Approvals (Normal features and bugs)