### PR TITLE
58 type annotation on other nodes

### DIFF
--- a/src/expressions/NamedFunctionRef.ts
+++ b/src/expressions/NamedFunctionRef.ts
@@ -24,7 +24,7 @@ class NamedFunctionRef extends Expression {
 	constructor(
 		functionReference: { localName: string; namespaceURI: string | null; prefix: string },
 		arity: number,
-		type?: SequenceType
+		type: SequenceType
 	) {
 		super(
 			new Specificity({

--- a/src/expressions/NamedFunctionRef.ts
+++ b/src/expressions/NamedFunctionRef.ts
@@ -1,5 +1,6 @@
 import FunctionValue from './dataTypes/FunctionValue';
 import sequenceFactory from './dataTypes/sequenceFactory';
+import { SequenceType } from './dataTypes/Value';
 import Expression from './Expression';
 import { FunctionProperties, getAlternativesAsStringFor } from './functions/functionRegistry';
 import Specificity from './Specificity';
@@ -22,7 +23,8 @@ class NamedFunctionRef extends Expression {
 
 	constructor(
 		functionReference: { localName: string; namespaceURI: string | null; prefix: string },
-		arity: number
+		arity: number,
+		type?: SequenceType
 	) {
 		super(
 			new Specificity({
@@ -31,7 +33,9 @@ class NamedFunctionRef extends Expression {
 			[],
 			{
 				canBeStaticallyEvaluated: true,
-			}
+			},
+			false,
+			type
 		);
 
 		this._arity = arity;

--- a/src/expressions/arrays/CurlyArrayConstructor.ts
+++ b/src/expressions/arrays/CurlyArrayConstructor.ts
@@ -1,12 +1,13 @@
 import ArrayValue from '../dataTypes/ArrayValue';
 import sequenceFactory from '../dataTypes/sequenceFactory';
+import { SequenceType } from '../dataTypes/Value';
 import Expression from '../Expression';
 import Specificity from '../Specificity';
 import createDoublyIterableSequence from '../util/createDoublyIterableSequence';
 
 class CurlyArrayConstructor extends Expression {
 	private _members: Expression[];
-	constructor(members: Expression[]) {
+	constructor(members: Expression[], type: SequenceType) {
 		super(
 			new Specificity({
 				[Specificity.EXTERNAL_KIND]: 1,
@@ -16,7 +17,9 @@ class CurlyArrayConstructor extends Expression {
 				canBeStaticallyEvaluated: members.every(
 					(member) => member.canBeStaticallyEvaluated
 				),
-			}
+			},
+			false,
+			type
 		);
 
 		this._members = members;

--- a/src/expressions/arrays/SquareArrayConstructor.ts
+++ b/src/expressions/arrays/SquareArrayConstructor.ts
@@ -1,12 +1,13 @@
 import ArrayValue from '../dataTypes/ArrayValue';
 import sequenceFactory from '../dataTypes/sequenceFactory';
+import { SequenceType } from '../dataTypes/Value';
 import Expression from '../Expression';
 import Specificity from '../Specificity';
 import createDoublyIterableSequence from '../util/createDoublyIterableSequence';
 
 class SquareArrayConstructor extends Expression {
 	private _members: Expression[];
-	constructor(members: Expression[]) {
+	constructor(members: Expression[], type: SequenceType) {
 		super(
 			new Specificity({
 				[Specificity.EXTERNAL_KIND]: 1,
@@ -16,7 +17,9 @@ class SquareArrayConstructor extends Expression {
 				canBeStaticallyEvaluated: members.every(
 					(member) => member.canBeStaticallyEvaluated
 				),
-			}
+			},
+			false,
+			type
 		);
 
 		this._members = members;

--- a/src/expressions/conditional/IfExpression.ts
+++ b/src/expressions/conditional/IfExpression.ts
@@ -1,6 +1,6 @@
 import ISequence from '../dataTypes/ISequence';
 import sequenceFactory from '../dataTypes/sequenceFactory';
-import Value from '../dataTypes/Value';
+import Value, { SequenceType } from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
@@ -15,23 +15,30 @@ class IfExpression extends PossiblyUpdatingExpression {
 	constructor(
 		testExpression: Expression,
 		thenExpression: PossiblyUpdatingExpression,
-		elseExpression: PossiblyUpdatingExpression
+		elseExpression: PossiblyUpdatingExpression,
+		type: SequenceType
 	) {
 		const specificity = testExpression.specificity
 			.add(thenExpression.specificity)
 			.add(elseExpression.specificity);
-		super(specificity, [testExpression, thenExpression, elseExpression], {
-			canBeStaticallyEvaluated:
-				testExpression.canBeStaticallyEvaluated &&
-				thenExpression.canBeStaticallyEvaluated &&
-				elseExpression.canBeStaticallyEvaluated,
-			peer: thenExpression.peer === elseExpression.peer && thenExpression.peer,
-			resultOrder:
-				thenExpression.expectedResultOrder === elseExpression.expectedResultOrder
-					? thenExpression.expectedResultOrder
-					: RESULT_ORDERINGS.UNSORTED,
-			subtree: thenExpression.subtree === elseExpression.subtree && thenExpression.subtree,
-		});
+		super(
+			specificity,
+			[testExpression, thenExpression, elseExpression],
+			{
+				canBeStaticallyEvaluated:
+					testExpression.canBeStaticallyEvaluated &&
+					thenExpression.canBeStaticallyEvaluated &&
+					elseExpression.canBeStaticallyEvaluated,
+				peer: thenExpression.peer === elseExpression.peer && thenExpression.peer,
+				resultOrder:
+					thenExpression.expectedResultOrder === elseExpression.expectedResultOrder
+						? thenExpression.expectedResultOrder
+						: RESULT_ORDERINGS.UNSORTED,
+				subtree:
+					thenExpression.subtree === elseExpression.subtree && thenExpression.subtree,
+			},
+			type
+		);
 
 		this._testExpression = testExpression;
 	}

--- a/src/expressions/maps/MapConstructor.ts
+++ b/src/expressions/maps/MapConstructor.ts
@@ -1,6 +1,7 @@
 import atomize from '../dataTypes/atomize';
 import MapValue from '../dataTypes/MapValue';
 import sequenceFactory from '../dataTypes/sequenceFactory';
+import { SequenceType } from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression from '../Expression';
@@ -13,7 +14,7 @@ class MapConstructor extends Expression {
 	/**
 	 * @param  entries  key-value tuples of expressions which will evaluate to key / value pairs
 	 */
-	constructor(entries: { key: Expression; value: Expression }[]) {
+	constructor(entries: { key: Expression; value: Expression }[], type: SequenceType) {
 		super(
 			new Specificity({
 				[Specificity.EXTERNAL_KIND]: 1,
@@ -24,7 +25,9 @@ class MapConstructor extends Expression {
 			),
 			{
 				canBeStaticallyEvaluated: false,
-			}
+			},
+			false,
+			type
 		);
 		this._entries = entries;
 	}

--- a/src/expressions/operators/SimpleMapOperator.ts
+++ b/src/expressions/operators/SimpleMapOperator.ts
@@ -1,5 +1,6 @@
 import ISequence from '../dataTypes/ISequence';
 import sequenceFactory from '../dataTypes/sequenceFactory';
+import { SequenceType } from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression from '../Expression';
@@ -15,11 +16,17 @@ class SimpleMapOperator extends Expression {
 	 * evaluating all expressions in expression2. Returns a sequence with results from the evaluation of expression2.
 	 * Order is undefined.
 	 */
-	constructor(expression1: Expression, expression2: Expression) {
-		super(new Specificity({}).add(expression1.specificity), [expression1, expression2], {
-			canBeStaticallyEvaluated:
-				expression1.canBeStaticallyEvaluated && expression2.canBeStaticallyEvaluated,
-		});
+	constructor(expression1: Expression, expression2: Expression, type: SequenceType) {
+		super(
+			new Specificity({}).add(expression1.specificity),
+			[expression1, expression2],
+			{
+				canBeStaticallyEvaluated:
+					expression1.canBeStaticallyEvaluated && expression2.canBeStaticallyEvaluated,
+			},
+			false,
+			type
+		);
 
 		this._expression1 = expression1;
 		this._expression2 = expression2;

--- a/src/expressions/operators/arithmetic/BinaryOperator.ts
+++ b/src/expressions/operators/arithmetic/BinaryOperator.ts
@@ -2,7 +2,7 @@ import AtomicValue from '../../../expressions/dataTypes/AtomicValue';
 import castToType from '../../../expressions/dataTypes/castToType';
 import createAtomicValue from '../../../expressions/dataTypes/createAtomicValue';
 import isSubtypeOf from '../../../expressions/dataTypes/isSubtypeOf';
-import { ValueType } from '../../../expressions/dataTypes/Value';
+import { ValueType, valueTypeToString } from '../../../expressions/dataTypes/Value';
 import { BinaryEvaluationFunction } from '../../../typeInference/binaryEvaluationFunction';
 import atomize from '../../dataTypes/atomize';
 import sequenceFactory from '../../dataTypes/sequenceFactory';
@@ -99,7 +99,11 @@ export function generateBinaryOperatorFunction(
 			}
 		}
 	}
-	throw new Error(`XPTY0004: ${operator} not available for types ${typeA} and ${typeB}`);
+	throw new Error(
+		`XPTY0004: ${operator} not available for types ${valueTypeToString(
+			typeA
+		)} and ${valueTypeToString(typeB)}`
+	);
 }
 
 /**
@@ -150,10 +154,6 @@ export function generateBinaryOperatorType(
 		return retType;
 	}
 
-	// check if the types have at least 1 applicable parent type each.
-	if (parentTypesOfB.length === 0 || parentTypesOfA.length === 0)
-		throw new Error(`XPTY0004: ${operator} not available for types ${typeA} and ${typeB}`);
-
 	// Loop through the 2 arrays to find a combination of parentTypes and operand that has an entry in the operationsMap and the returnTypeMap.
 	for (const typeOfA of parentTypesOfA) {
 		for (const typeOfB of parentTypesOfB) {
@@ -163,7 +163,11 @@ export function generateBinaryOperatorType(
 			}
 		}
 	}
-	throw new Error(`XPTY0004: ${operator} not available for types ${typeA} and ${typeB}`);
+	throw new Error(
+		`XPTY0004: ${operator} not available for types ${valueTypeToString(
+			typeA
+		)} and ${valueTypeToString(typeB)}`
+	);
 }
 
 /**

--- a/src/expressions/operators/types/InstanceOfOperator.ts
+++ b/src/expressions/operators/types/InstanceOfOperator.ts
@@ -20,7 +20,7 @@ class InstanceOfOperator extends Expression {
 			expression.specificity,
 			[expression],
 			{ canBeStaticallyEvaluated: false },
-			undefined,
+			false,
 			type
 		);
 

--- a/src/expressions/operators/types/InstanceOfOperator.ts
+++ b/src/expressions/operators/types/InstanceOfOperator.ts
@@ -1,3 +1,4 @@
+import { SequenceType } from '../../../expressions/dataTypes/Value';
 import sequenceFactory from '../../dataTypes/sequenceFactory';
 import DynamicContext from '../../DynamicContext';
 import ExecutionParameters from '../../ExecutionParameters';
@@ -9,8 +10,19 @@ class InstanceOfOperator extends Expression {
 	private _multiplicity: string;
 	private _typeTest: Expression;
 
-	constructor(expression: Expression, typeTest: Expression, multiplicity: string) {
-		super(expression.specificity, [expression], { canBeStaticallyEvaluated: false });
+	constructor(
+		expression: Expression,
+		typeTest: Expression,
+		multiplicity: string,
+		type: SequenceType
+	) {
+		super(
+			expression.specificity,
+			[expression],
+			{ canBeStaticallyEvaluated: false },
+			undefined,
+			type
+		);
 
 		this._expression = expression;
 		this._typeTest = typeTest;

--- a/src/expressions/path/ContextItemExpression.ts
+++ b/src/expressions/path/ContextItemExpression.ts
@@ -1,12 +1,19 @@
 import sequenceFactory from '../dataTypes/sequenceFactory';
+import { SequenceType } from '../dataTypes/Value';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
 import Specificity from '../Specificity';
 
 class ContextItemExpression extends Expression {
-	constructor() {
-		super(new Specificity({}), [], {
-			resultOrder: RESULT_ORDERINGS.SORTED,
-		});
+	constructor(type: SequenceType) {
+		super(
+			new Specificity({}),
+			[],
+			{
+				resultOrder: RESULT_ORDERINGS.SORTED,
+			},
+			false,
+			type
+		);
 	}
 
 	public evaluate(dynamicContext, _executionParameters) {

--- a/src/expressions/postfix/UnaryLookup.ts
+++ b/src/expressions/postfix/UnaryLookup.ts
@@ -1,4 +1,5 @@
 import EmptySequence from '../dataTypes/Sequences/EmptySequence';
+import { SequenceType } from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression from '../Expression';
@@ -8,13 +9,15 @@ import evaluateLookup from './evaluateLookup';
 class UnaryLookup extends Expression {
 	private readonly _keySpecifier: '*' | Expression;
 
-	constructor(keySpecifier: '*' | Expression) {
+	constructor(keySpecifier: '*' | Expression, type: SequenceType) {
 		super(
 			new Specificity({
 				[Specificity.EXTERNAL_KIND]: 1,
 			}),
 			keySpecifier === '*' ? [] : [keySpecifier],
-			{ canBeStaticallyEvaluated: false }
+			{ canBeStaticallyEvaluated: false },
+			false,
+			type
 		);
 
 		this._keySpecifier = keySpecifier;

--- a/src/expressions/quantified/QuantifiedExpression.ts
+++ b/src/expressions/quantified/QuantifiedExpression.ts
@@ -1,4 +1,5 @@
 import sequenceFactory from '../dataTypes/sequenceFactory';
+import { SequenceType } from '../dataTypes/Value';
 import Expression from '../Expression';
 
 type InClause = {
@@ -13,7 +14,12 @@ class QuantifiedExpression extends Expression {
 	public _quantifier: string;
 	public _satisfiesExpr: Expression;
 
-	constructor(quantifier: string, inClauses: InClause[], satisfiesExpr: Expression) {
+	constructor(
+		quantifier: string,
+		inClauses: InClause[],
+		satisfiesExpr: Expression,
+		type: SequenceType
+	) {
 		const inClauseExpressions = inClauses.map((inClause) => inClause.sourceExpr);
 		const inClauseNames = inClauses.map((inClause) => inClause.name);
 
@@ -21,9 +27,15 @@ class QuantifiedExpression extends Expression {
 			(summedSpecificity, inClause) => summedSpecificity.add(inClause.specificity),
 			satisfiesExpr.specificity
 		);
-		super(specificity, inClauseExpressions.concat(satisfiesExpr), {
-			canBeStaticallyEvaluated: false,
-		});
+		super(
+			specificity,
+			inClauseExpressions.concat(satisfiesExpr),
+			{
+				canBeStaticallyEvaluated: false,
+			},
+			false,
+			type
+		);
 
 		this._quantifier = quantifier;
 		this._inClauseNames = inClauseNames;

--- a/src/expressions/xquery/TypeSwitchExpression.ts
+++ b/src/expressions/xquery/TypeSwitchExpression.ts
@@ -1,9 +1,10 @@
 import ISequence from '../dataTypes/ISequence';
 import sequenceFactory from '../dataTypes/sequenceFactory';
+import { SequenceType } from '../dataTypes/Value';
 import DynamicContext from '../DynamicContext';
 import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
-import PossiblyUpdatingExpression from '../PossiblyUpdatingExpression';
+import PossiblyUpdatingExpression, { SequenceCallbacks } from '../PossiblyUpdatingExpression';
 import Specificity from '../Specificity';
 import StaticContext from '../StaticContext';
 import { errXUST0001 } from '../xquery-update/XQueryUpdateFacilityErrors';
@@ -26,7 +27,8 @@ class TypeSwitchExpression extends PossiblyUpdatingExpression {
 	constructor(
 		argExpression: Expression,
 		caseClauses: TypeSwitchCaseClause[],
-		defaultExpression: PossiblyUpdatingExpression
+		defaultExpression: PossiblyUpdatingExpression,
+		type: SequenceType
 	) {
 		const specificity = new Specificity({});
 		super(
@@ -45,7 +47,8 @@ class TypeSwitchExpression extends PossiblyUpdatingExpression {
 				peer: false,
 				resultOrder: RESULT_ORDERINGS.UNSORTED,
 				subtree: false,
-			}
+			},
+			type
 		);
 		this._argExpression = argExpression;
 		this._amountOfCases = caseClauses.length;

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -316,6 +316,7 @@ function arrayConstructor(ast: IAST, compilationOptions: CompilationOptions) {
 }
 
 function mapConstructor(ast: IAST, compilationOptions: CompilationOptions) {
+	const typeNode = astHelper.followPath(ast, ['type']);
 	return new MapConstructor(
 		astHelper.getChildren(ast, 'mapConstructorEntry').map((keyValuePair) => ({
 			key: compile(
@@ -326,7 +327,8 @@ function mapConstructor(ast: IAST, compilationOptions: CompilationOptions) {
 				astHelper.followPath(keyValuePair, ['mapValueExpr', '*']),
 				disallowUpdating(compilationOptions)
 			),
-		}))
+		})),
+		typeNode ? (typeNode[1] as SequenceType) : undefined
 	);
 }
 

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -460,6 +460,7 @@ function compare(ast: IAST, compilationOptions: CompilationOptions) {
 }
 
 function IfThenElseExpr(ast: IAST, compilationOptions: CompilationOptions) {
+	const retType = astHelper.getAttribute(ast, 'type');
 	return new IfExpression(
 		compile(
 			astHelper.getFirstChild(astHelper.getFirstChild(ast, 'ifClause'), '*'),
@@ -472,7 +473,8 @@ function IfThenElseExpr(ast: IAST, compilationOptions: CompilationOptions) {
 		compile(
 			astHelper.getFirstChild(astHelper.getFirstChild(ast, 'elseClause'), '*'),
 			compilationOptions
-		) as PossiblyUpdatingExpression
+		) as PossiblyUpdatingExpression,
+		retType ? (retType[1] as SequenceType) : undefined
 	);
 }
 

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -1,3 +1,4 @@
+import { isUndefined } from 'util';
 import CurlyArrayConstructor from '../expressions/arrays/CurlyArrayConstructor';
 import SquareArrayConstructor from '../expressions/arrays/SquareArrayConstructor';
 import AncestorAxis from '../expressions/axes/AncestorAxis';
@@ -1423,6 +1424,8 @@ function typeswitchExpr(ast: IAST, compilationOptions: CompilationOptions) {
 		throw new Error('XPST0003: Use of XQuery functionality is not allowed in XPath context');
 	}
 
+	const typeNode = astHelper.followPath(ast, ['type']);
+
 	const argExpr = compile(
 		astHelper.getFirstChild(astHelper.getFirstChild(ast, 'argExpr'), '*'),
 		compilationOptions
@@ -1471,7 +1474,12 @@ function typeswitchExpr(ast: IAST, compilationOptions: CompilationOptions) {
 		compilationOptions
 	) as PossiblyUpdatingExpression;
 
-	return new TypeSwitchExpression(argExpr, caseClauseExpressions, defaultExpression);
+	return new TypeSwitchExpression(
+		argExpr,
+		caseClauseExpressions,
+		defaultExpression,
+		typeNode ? (typeNode[1] as SequenceType) : undefined
+	);
 }
 
 export default function (xPathAst: IAST, compilationOptions: CompilationOptions): Expression {

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -1030,11 +1030,16 @@ function sequence(ast: IAST, compilationOptions: CompilationOptions) {
 }
 
 function simpleMap(ast: IAST, compilationOptions: CompilationOptions) {
+	const typeNode = astHelper.followPath(ast, ['type']);
 	return astHelper.getChildren(ast, '*').reduce((lhs: Expression, rhs: IAST) => {
 		if (lhs === null) {
 			return compile(rhs, disallowUpdating(compilationOptions));
 		}
-		return new SimpleMapOperator(lhs, compile(rhs, disallowUpdating(compilationOptions)));
+		return new SimpleMapOperator(
+			lhs,
+			compile(rhs, disallowUpdating(compilationOptions)),
+			typeNode ? (typeNode[1] as SequenceType) : undefined
+		);
 	}, null);
 }
 

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -11,11 +11,7 @@ import PrecedingAxis from '../expressions/axes/PrecedingAxis';
 import PrecedingSiblingAxis from '../expressions/axes/PrecedingSiblingAxis';
 import SelfAxis from '../expressions/axes/SelfAxis';
 import IfExpression from '../expressions/conditional/IfExpression';
-import Value, {
-	SequenceMultiplicity,
-	SequenceType,
-	ValueType,
-} from '../expressions/dataTypes/Value';
+import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import QName from '../expressions/dataTypes/valueTypes/QName';
 import StackTraceGenerator, { SourceRange } from '../expressions/debug/StackTraceGenerator';
 import Expression, { RESULT_ORDERINGS } from '../expressions/Expression';
@@ -994,6 +990,7 @@ function textTest(_ast: IAST, _compilationOptions: CompilationOptions) {
 }
 
 function quantified(ast: IAST, compilationOptions: CompilationOptions) {
+	const typeNode: IAST = astHelper.followPath(ast, ['type']);
 	const quantifier = astHelper.getTextContent(astHelper.getFirstChild(ast, 'quantifier'));
 	const predicateExpr = astHelper.followPath(ast, ['predicateExpr', '*']);
 	const quantifierInClauses = astHelper
@@ -1010,7 +1007,8 @@ function quantified(ast: IAST, compilationOptions: CompilationOptions) {
 	return new QuantifiedExpression(
 		quantifier,
 		quantifierInClauses,
-		compile(predicateExpr, disallowUpdating(compilationOptions))
+		compile(predicateExpr, disallowUpdating(compilationOptions)),
+		typeNode ? (typeNode[1] as SequenceType) : undefined
 	);
 }
 

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -292,6 +292,7 @@ function stackTrace(ast: IAST, compilationOptions: CompilationOptions) {
 }
 
 function arrayConstructor(ast: IAST, compilationOptions: CompilationOptions) {
+	const typeNode = astHelper.followPath(ast, ['type']);
 	const arrConstructor = astHelper.getFirstChild(ast, '*');
 	const members = astHelper
 		.getChildren(arrConstructor, 'arrayElem')
@@ -300,9 +301,15 @@ function arrayConstructor(ast: IAST, compilationOptions: CompilationOptions) {
 		);
 	switch (arrConstructor[0]) {
 		case 'curlyArray':
-			return new CurlyArrayConstructor(members);
+			return new CurlyArrayConstructor(
+				members,
+				typeNode ? (typeNode[1] as SequenceType) : undefined
+			);
 		case 'squareArray':
-			return new SquareArrayConstructor(members);
+			return new SquareArrayConstructor(
+				members,
+				typeNode ? (typeNode[1] as SequenceType) : undefined
+			);
 		default:
 			throw new Error('Unrecognized arrayType: ' + arrConstructor[0]);
 	}

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -654,6 +654,7 @@ function functionCall(
 }
 
 function arrowExpr(ast: IAST, compilationOptions: CompilationOptions) {
+	const typeNode = astHelper.followPath(ast, ['type']);
 	const argExpr = astHelper.followPath(ast, ['argExpr', '*']);
 
 	// Each part an EQName, expression, or arguments passed to the previous part
@@ -677,7 +678,7 @@ function arrowExpr(ast: IAST, compilationOptions: CompilationOptions) {
 			parts[i][0] === 'EQName'
 				? new NamedFunctionRef(astHelper.getQName(parts[i]), args.length)
 				: compile(parts[i], disallowUpdating(compilationOptions));
-		args = [new FunctionCall(func, args)];
+		args = [new FunctionCall(func, args, typeNode ? (typeNode[1] as SequenceType) : undefined)];
 	}
 	return args[0];
 }

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -645,7 +645,11 @@ function functionCall(
 	const returnType = astHelper.followPath(ast, ['type']);
 
 	return new FunctionCall(
-		new NamedFunctionRef(astHelper.getQName(functionName), functionArguments.length),
+		new NamedFunctionRef(
+			astHelper.getQName(functionName),
+			functionArguments.length,
+			returnType ? (returnType[1] as SequenceType) : undefined
+		),
 		functionArguments.map((arg) =>
 			arg[0] === 'argumentPlaceholder' ? null : compile(arg, compilationOptions)
 		),
@@ -655,7 +659,7 @@ function functionCall(
 
 function arrowExpr(ast: IAST, compilationOptions: CompilationOptions) {
 	const argExpr = astHelper.followPath(ast, ['argExpr', '*']);
-
+	const typeNode = astHelper.followPath(ast, ['type']);
 	// Each part an EQName, expression, or arguments passed to the previous part
 	const parts = astHelper.getChildren(ast, '*').slice(1);
 
@@ -675,7 +679,11 @@ function arrowExpr(ast: IAST, compilationOptions: CompilationOptions) {
 
 		const func =
 			parts[i][0] === 'EQName'
-				? new NamedFunctionRef(astHelper.getQName(parts[i]), args.length)
+				? new NamedFunctionRef(
+						astHelper.getQName(parts[i]),
+						args.length,
+						typeNode ? (typeNode[1] as SequenceType) : undefined
+				  )
 				: compile(parts[i], disallowUpdating(compilationOptions));
 		args = [new FunctionCall(func, args)];
 	}
@@ -699,10 +707,15 @@ function dynamicFunctionInvocationExpr(ast: IAST, compilationOptions: Compilatio
 
 function namedFunctionRef(ast: IAST, _compilationOptions: CompilationOptions) {
 	const functionName = astHelper.getFirstChild(ast, 'functionName');
+	const typeNode = astHelper.followPath(ast, ['type']);
 	const arity = astHelper.getTextContent(
 		astHelper.followPath(ast, ['integerConstantExpr', 'value'])
 	);
-	return new NamedFunctionRef(astHelper.getQName(functionName), parseInt(arity, 10));
+	return new NamedFunctionRef(
+		astHelper.getQName(functionName),
+		parseInt(arity, 10),
+		typeNode ? (typeNode[1] as SequenceType) : undefined
+	);
 }
 
 function inlineFunction(
@@ -1025,7 +1038,8 @@ function stringConcatenateOp(ast: IAST, compilationOptions: CompilationOptions) 
 				namespaceURI: 'http://www.w3.org/2005/xpath-functions',
 				prefix: '',
 			},
-			args.length
+			args.length,
+			typeNode ? (typeNode[1] as SequenceType) : undefined
 		),
 		args.map((arg) => compile(arg, disallowUpdating(compilationOptions))),
 		typeNode ? (typeNode[1] as SequenceType) : undefined
@@ -1045,7 +1059,8 @@ function rangeSequenceExpr(ast: IAST, compilationOptions: CompilationOptions) {
 			namespaceURI: 'http://fontoxpath/operators',
 			prefix: '',
 		},
-		args.length
+		args.length,
+		typeNode ? (typeNode[1] as SequenceType) : undefined
 	);
 
 	return new FunctionCall(

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -1,4 +1,3 @@
-import { isUndefined } from 'util';
 import CurlyArrayConstructor from '../expressions/arrays/CurlyArrayConstructor';
 import SquareArrayConstructor from '../expressions/arrays/SquareArrayConstructor';
 import AncestorAxis from '../expressions/axes/AncestorAxis';

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -741,11 +741,13 @@ function instanceOf(
 	const expression = compile(astHelper.followPath(ast, ['argExpr', '*']), compilationOptions);
 	const sequenceType = astHelper.followPath(ast, ['sequenceType', '*']);
 	const occurrence = astHelper.followPath(ast, ['sequenceType', 'occurrenceIndicator']);
+	const typeNode = astHelper.followPath(ast, ['type']);
 
 	return new InstanceOfOperator(
 		expression,
 		compile(sequenceType, disallowUpdating(compilationOptions)),
-		occurrence ? astHelper.getTextContent(occurrence) : ''
+		occurrence ? astHelper.getTextContent(occurrence) : '',
+		typeNode ? (typeNode[1] as SequenceType) : undefined
 	);
 }
 

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -11,7 +11,11 @@ import PrecedingAxis from '../expressions/axes/PrecedingAxis';
 import PrecedingSiblingAxis from '../expressions/axes/PrecedingSiblingAxis';
 import SelfAxis from '../expressions/axes/SelfAxis';
 import IfExpression from '../expressions/conditional/IfExpression';
-import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import Value, {
+	SequenceMultiplicity,
+	SequenceType,
+	ValueType,
+} from '../expressions/dataTypes/Value';
 import QName from '../expressions/dataTypes/valueTypes/QName';
 import StackTraceGenerator, { SourceRange } from '../expressions/debug/StackTraceGenerator';
 import Expression, { RESULT_ORDERINGS } from '../expressions/Expression';
@@ -380,22 +384,13 @@ function binaryOperator(ast: IAST, compilationOptions: CompilationOptions) {
 		astHelper.followPath(ast, ['secondOperand', '*']),
 		'type'
 	) as SequenceType;
-	let firstType;
-	let secondType;
-	let evaluateFunction;
-	if (first && second) {
-		firstType = first.type;
-		secondType = second.type;
-		evaluateFunction = generateBinaryOperatorFunction(kind, firstType, secondType);
+
+	let evaluateFunction: BinaryEvaluationFunction;
+	if (first && second && astHelper.getAttribute(ast, 'type')) {
+		evaluateFunction = generateBinaryOperatorFunction(kind, first.type, second.type);
 	}
 
-	return new BinaryOperator(
-		kind,
-		a,
-		b,
-		attributeType as SequenceType,
-		evaluateFunction as BinaryEvaluationFunction
-	);
+	return new BinaryOperator(kind, a, b, attributeType as SequenceType, evaluateFunction);
 }
 
 function compileLookup(ast: IAST, compilationOptions: CompilationOptions): '*' | Expression {
@@ -790,6 +785,7 @@ function anyItemTest() {
 }
 
 function pathExpr(ast: IAST, compilationOptions: CompilationOptions) {
+	const typeNode = astHelper.followPath(ast, ['type']);
 	const rawSteps = astHelper.getChildren(ast, 'stepExpr');
 	let hasAxisStep = false;
 	const steps = rawSteps.map((step) => {
@@ -892,6 +888,7 @@ function pathExpr(ast: IAST, compilationOptions: CompilationOptions) {
 			}
 		}
 
+		stepExpression.type = typeNode ? (typeNode[1] as SequenceType) : undefined;
 		return stepExpression;
 	});
 

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -142,7 +142,8 @@ function compile(ast: IAST, compilationOptions: CompilationOptions): Expression 
 		case 'pathExpr':
 			return pathExpr(ast, compilationOptions);
 		case 'contextItemExpr':
-			return new ContextItemExpression();
+			const typeNode = astHelper.followPath(ast, ['type']);
+			return new ContextItemExpression(typeNode ? (typeNode[1] as SequenceType) : undefined);
 
 		// Functions
 		case 'functionCallExpr':

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -684,7 +684,7 @@ function arrowExpr(ast: IAST, compilationOptions: CompilationOptions) {
 
 function dynamicFunctionInvocationExpr(ast: IAST, compilationOptions: CompilationOptions) {
 	const functionItemContent = astHelper.followPath(ast, ['functionItem', '*']);
-
+	const retType: IAST = astHelper.followPath(ast, ['type']);
 	const argumentsAst = astHelper.getFirstChild(ast, 'arguments');
 	let args = [];
 	if (argumentsAst) {
@@ -694,7 +694,11 @@ function dynamicFunctionInvocationExpr(ast: IAST, compilationOptions: Compilatio
 		);
 	}
 
-	return new FunctionCall(compile(functionItemContent, compilationOptions), args);
+	return new FunctionCall(
+		compile(functionItemContent, compilationOptions),
+		args,
+		retType ? (retType[1] as SequenceType) : undefined
+	);
 }
 
 function namedFunctionRef(ast: IAST, _compilationOptions: CompilationOptions) {

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -198,7 +198,11 @@ function compile(ast: IAST, compilationOptions: CompilationOptions): Expression 
 			return arrayConstructor(ast, compilationOptions);
 
 		case 'unaryLookup':
-			return new UnaryLookup(compileLookup(ast, compilationOptions));
+			const returnType = astHelper.followPath(ast, ['type']);
+			return new UnaryLookup(
+				compileLookup(ast, compilationOptions),
+				returnType ? (returnType[1] as SequenceType) : undefined
+			);
 
 		case 'typeswitchExpr':
 			return typeswitchExpr(ast, compilationOptions);

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -13,6 +13,7 @@ import { annotateContextItemExpr } from './annotateContextItemExpr';
 import { annotateFunctionCall } from './annotateFunctionCall';
 import { annotateInstanceOfExpr } from './annotateInstanceOfExpr';
 import { annotateLogicalOperator } from './annotateLogicalOperator';
+import { annotateMapConstructor } from './annotateMapConstructor';
 import { annotatePathExpr } from './annotatePathExpr';
 import { annotateRangeSequenceOperator } from './annotateRangeSequenceOperator';
 import { annotateSequenceOperator } from './annotateSequenceOperator';
@@ -213,8 +214,25 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 		case 'castableExpr':
 			return annotateCastableOperator(ast);
 
+		// Maps
+		case 'mapConstructor':
+			astHelper.getChildren(ast, 'mapConstructorEntry').map((keyValuePair) => ({
+				key: annotate(
+					astHelper.followPath(keyValuePair, ['mapKeyExpr', '*']),
+					staticContext
+				),
+				value: annotate(
+					astHelper.followPath(keyValuePair, ['mapValueExpr', '*']),
+					staticContext
+				),
+			}));
+			return annotateMapConstructor(ast);
+
 		// Arrays
 		case 'arrayConstructor':
+			astHelper
+				.getChildren(astHelper.getFirstChild(ast, '*'), 'arrayElem')
+				.map((arrayElem) => annotate(arrayElem, staticContext));
 			return annotateArrayConstructor(ast);
 
 		// TypeSwitch

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -9,6 +9,7 @@ import {
 	annotateValueCompare,
 } from './annotateCompareOperator';
 import { annotateFunctionCall } from './annotateFunctionCall';
+import { annotateInstanceOfExpr } from './annotateInstanceOfExpr';
 import { annotateLogicalOperator } from './annotateLogicalOperator';
 import { annotateRangeSequenceOperator } from './annotateRangeSequenceOperator';
 import { annotateSequenceOperator } from './annotateSequenceOperator';
@@ -149,6 +150,7 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 		case 'instanceOfExpr': {
 			annotate(astHelper.getFirstChild(ast, 'argExpr'), staticContext);
 			annotate(astHelper.getFirstChild(ast, 'sequenceType'), staticContext);
+			annotateInstanceOfExpr(ast);
 		}
 		// Constant expressions
 		case 'integerConstantExpr':

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -269,6 +269,10 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 			annotateTypeSwitchOperator(ast);
 
 		case 'quantifiedExpr':
+			// Variable amount of children from this AST node, solution: looping through them
+			for (let iterationCounter = 1; iterationCounter < ast.length; iterationCounter++) {
+				annotate(ast[iterationCounter] as IAST, staticContext);
+			}
 			return annotateQuantifiedExpr(ast);
 
 		default:

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -9,6 +9,7 @@ import {
 	annotateValueCompare,
 } from './annotateCompareOperator';
 import { annotateContextItemExpr } from './annotateContextItemExpr';
+import { annotateDynamicFunctionInvocationExpr } from './annotateDynamicFunctionInvocationExpr';
 import { annotateFunctionCall } from './annotateFunctionCall';
 import { annotateInstanceOfExpr } from './annotateInstanceOfExpr';
 import { annotateLogicalOperator } from './annotateLogicalOperator';
@@ -205,7 +206,16 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 		// Functions
 		case 'functionCallExpr':
 			return annotateFunctionCall(ast, staticContext);
-
+		case 'dynamicFunctionInvocationExpr':
+			const functionItem: SequenceType = annotate(
+				astHelper.followPath(ast, ['functionItem', '*']),
+				staticContext
+			);
+			const args: SequenceType = annotate(
+				astHelper.getFirstChild(ast, 'arguments'),
+				staticContext
+			);
+			return annotateDynamicFunctionInvocationExpr(ast, staticContext, functionItem, args);
 		// Casting
 		case 'castExpr':
 			return annotateCastOperator(ast);

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -205,7 +205,9 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 		// Functions
 		case 'functionCallExpr':
 			return annotateFunctionCall(ast, staticContext);
-
+		case 'inlineFunctionExpr':
+			annotate(astHelper.getFirstChild(ast, 'functionBody')[1] as IAST, staticContext);
+			return { type: ValueType.FUNCTION, mult: SequenceMultiplicity.EXACTLY_ONE };
 		// Casting
 		case 'castExpr':
 			return annotateCastOperator(ast);

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -1,6 +1,7 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { annotateArrayConstructor } from './annotateArrayConstructor';
 import { annotateBinOp } from './annotateBinaryOperator';
 import { annotateCastableOperator, annotateCastOperator } from './annotateCastOperators';
 import {
@@ -211,6 +212,10 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 			return annotateCastOperator(ast);
 		case 'castableExpr':
 			return annotateCastableOperator(ast);
+
+		// Arrays
+		case 'arrayConstructor':
+			return annotateArrayConstructor(ast);
 
 		// TypeSwitch
 		case 'typeSwitchExpr':

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -8,6 +8,7 @@ import {
 	annotateNodeCompare,
 	annotateValueCompare,
 } from './annotateCompareOperator';
+import { annotateContextItemExpr } from './annotateContextItemExpr';
 import { annotateFunctionCall } from './annotateFunctionCall';
 import { annotateInstanceOfExpr } from './annotateInstanceOfExpr';
 import { annotateLogicalOperator } from './annotateLogicalOperator';
@@ -156,6 +157,10 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 			if (root) annotate(root[1] as IAST, staticContext);
 			astHelper.getChildren(ast, 'stepExpr').map((b) => annotate(b, staticContext));
 			return annotatePathExpr(ast);
+
+		// Context Item
+		case 'contextItemExpr':
+			return annotateContextItemExpr(ast);
 
 		case 'instanceOfExpr': {
 			annotate(astHelper.getFirstChild(ast, 'argExpr'), staticContext);

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -185,6 +185,16 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 			return annotateCastOperator(ast);
 		case 'castableExpr':
 			return annotateCastableOperator(ast);
+		case 'typeSwitchExpr':
+			const arg = annotate(astHelper.getFirstChild(ast, 'argExpr') as IAST, staticContext);
+			const clauses = (astHelper.getChildren(
+				ast,
+				'typeswitchExprCaseClause'
+			) as IAST[]).map((a) => annotate(a, staticContext));
+			const defaultCase = annotate(
+				astHelper.getFirstChild(ast, 'typeSwitchExprDefaultClause') as IAST,
+				staticContext
+			);
 		default:
 			// Current node cannot be annotated, but maybe deeper ones can.
 			for (let i = 1; i < ast.length; i++) {

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -1,6 +1,7 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { annotateArrowExpr } from './annotateArrowExpr';
 import { annotateBinOp } from './annotateBinaryOperator';
 import { annotateCastableOperator, annotateCastOperator } from './annotateCastOperators';
 import {
@@ -205,6 +206,8 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 		// Functions
 		case 'functionCallExpr':
 			return annotateFunctionCall(ast, staticContext);
+		case 'arrowExpr':
+			return annotateArrowExpr(ast, staticContext);
 
 		// Casting
 		case 'castExpr':

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -211,7 +211,7 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 		case 'inlineFunctionExpr':
 			annotate(astHelper.getFirstChild(ast, 'functionBody')[1] as IAST, staticContext);
 			return { type: ValueType.FUNCTION, mult: SequenceMultiplicity.EXACTLY_ONE };
-      
+
 		// Casting
 		case 'castExpr':
 			return annotateCastOperator(ast);

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -23,6 +23,7 @@ import { annotateSequenceOperator } from './annotateSequenceOperator';
 import { annotateSetOperator } from './annotateSetOperators';
 import { annotateStringConcatenateOperator } from './annotateStringConcatenateOperator';
 import { annotateTypeSwitchOperator } from './annotateTypeSwitchOperator';
+import { annotateUnaryLookup } from './annotateUnaryLookup';
 import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
 
 /**
@@ -254,6 +255,11 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 				.getChildren(astHelper.getFirstChild(ast, '*'), 'arrayElem')
 				.map((arrayElem) => annotate(arrayElem, staticContext));
 			return annotateArrayConstructor(ast);
+
+		// Unary Lookup
+		case 'unaryLookup':
+			const ncName = astHelper.getFirstChild(ast, 'NCName');
+			return annotateUnaryLookup(ast, ncName);
 
 		// TypeSwitch
 		case 'typeSwitchExpr':

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -152,7 +152,7 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 		case 'pathExpr':
 			const root = astHelper.getFirstChild(ast, 'rootExpr');
 			if (root) annotate(root[1] as IAST, staticContext);
-			astHelper.getChildren(ast, 'stepExpr').map((arg) => annotate(arg, staticContext));
+			astHelper.getChildren(ast, 'stepExpr').map((b) => annotate(b, staticContext));
 			return annotatePathExpr(ast);
 
 		// Constant expressions

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -162,14 +162,14 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 			annotate(astHelper.getFirstChild(ast, 'sequenceType'), staticContext);
 			annotateInstanceOfExpr(ast);
 		}
-      
+
 		// Constant expressions
 		case 'integerConstantExpr':
 			const integerSequenceType = {
 				type: ValueType.XSINTEGER,
 				mult: SequenceMultiplicity.EXACTLY_ONE,
 			};
-      
+
 			astHelper.insertAttribute(ast, 'type', integerSequenceType);
 			return integerSequenceType;
 		case 'doubleConstantExpr':
@@ -196,18 +196,18 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 
 			astHelper.insertAttribute(ast, 'type', stringSequenceType);
 			return stringSequenceType;
-    
-    // Functions
+
+		// Functions
 		case 'functionCallExpr':
 			return annotateFunctionCall(ast, staticContext);
-     
-    // Casting
+
+		// Casting
 		case 'castExpr':
 			return annotateCastOperator(ast);
 		case 'castableExpr':
 			return annotateCastableOperator(ast);
-    
-    // TypeSwitch
+
+		// TypeSwitch
 		case 'typeSwitchExpr':
 			const arg = annotate(astHelper.getFirstChild(ast, 'argExpr') as IAST, staticContext);
 			const clauses = astHelper
@@ -218,7 +218,7 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 				staticContext
 			);
 			annotateTypeSwitchOperator(ast);
-      
+
 		default:
 			// Current node cannot be annotated, but maybe deeper ones can.
 			for (let i = 1; i < ast.length; i++) {

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -12,6 +12,7 @@ import { annotateContextItemExpr } from './annotateContextItemExpr';
 import { annotateFunctionCall } from './annotateFunctionCall';
 import { annotateInstanceOfExpr } from './annotateInstanceOfExpr';
 import { annotateLogicalOperator } from './annotateLogicalOperator';
+import { annotateNamedFunctionRef } from './annotateNamedFunctionRef';
 import { annotatePathExpr } from './annotatePathExpr';
 import { annotateRangeSequenceOperator } from './annotateRangeSequenceOperator';
 import { annotateSequenceOperator } from './annotateSequenceOperator';
@@ -205,6 +206,8 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 		// Functions
 		case 'functionCallExpr':
 			return annotateFunctionCall(ast, staticContext);
+		case 'namedFunctionRef':
+			return annotateNamedFunctionRef(ast, staticContext);
 
 		// Casting
 		case 'castExpr':

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -188,7 +188,7 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 		case 'instanceOfExpr': {
 			annotate(astHelper.getFirstChild(ast, 'argExpr'), staticContext);
 			annotate(astHelper.getFirstChild(ast, 'sequenceType'), staticContext);
-			annotateInstanceOfExpr(ast);
+			return annotateInstanceOfExpr(ast);
 		}
 
 		// Constant expressions
@@ -291,7 +291,7 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 				astHelper.getFirstChild(ast, 'typeSwitchExprDefaultClause') as IAST,
 				staticContext
 			);
-			annotateTypeSwitchOperator(ast);
+			return annotateTypeSwitchOperator(ast);
 
 		case 'quantifiedExpr':
 			astHelper.getChildren(ast, '*').map((a) => annotate(a, staticContext));

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -21,6 +21,7 @@ import { annotatePathExpr } from './annotatePathExpr';
 import { annotateRangeSequenceOperator } from './annotateRangeSequenceOperator';
 import { annotateSequenceOperator } from './annotateSequenceOperator';
 import { annotateSetOperator } from './annotateSetOperators';
+import { annotateSimpleMapExpr } from './annotateSimpleMapExpr';
 import { annotateStringConcatenateOperator } from './annotateStringConcatenateOperator';
 import { annotateTypeSwitchOperator } from './annotateTypeSwitchOperator';
 import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
@@ -235,6 +236,9 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 			return annotateCastableOperator(ast);
 
 		// Maps
+		case 'simpleMapExpr':
+			astHelper.getChildren(ast, 'pathExpr').map((c) => annotate(c, staticContext));
+			return annotateSimpleMapExpr(ast);
 		case 'mapConstructor':
 			astHelper.getChildren(ast, 'mapConstructorEntry').map((keyValuePair) => ({
 				key: annotate(

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -18,6 +18,7 @@ import { annotateLogicalOperator } from './annotateLogicalOperator';
 import { annotateMapConstructor } from './annotateMapConstructor';
 import { annotateNamedFunctionRef } from './annotateNamedFunctionRef';
 import { annotatePathExpr } from './annotatePathExpr';
+import { annotateQuantifiedExpr } from './annotateQuantifiedExpr';
 import { annotateRangeSequenceOperator } from './annotateRangeSequenceOperator';
 import { annotateSequenceOperator } from './annotateSequenceOperator';
 import { annotateSetOperator } from './annotateSetOperators';
@@ -266,6 +267,9 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 				staticContext
 			);
 			annotateTypeSwitchOperator(ast);
+
+		case 'quantifiedExpr':
+			return annotateQuantifiedExpr(ast);
 
 		default:
 			// Current node cannot be annotated, but maybe deeper ones can.

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -13,6 +13,7 @@ import {
 import { annotateContextItemExpr } from './annotateContextItemExpr';
 import { annotateDynamicFunctionInvocationExpr } from './annotateDynamicFunctionInvocationExpr';
 import { annotateFunctionCall } from './annotateFunctionCall';
+import { annotateIfThenElseExpr } from './annotateIfThenElseExpr';
 import { annotateInstanceOfExpr } from './annotateInstanceOfExpr';
 import { annotateLogicalOperator } from './annotateLogicalOperator';
 import { annotateMapConstructor } from './annotateMapConstructor';
@@ -178,6 +179,7 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 				astHelper.getFirstChild(astHelper.getFirstChild(ast, 'elseClause'), '*'),
 				staticContext
 			);
+			return annotateIfThenElseExpr(ast, thenClause, elseClause);
 		}
 		case 'instanceOfExpr': {
 			annotate(astHelper.getFirstChild(ast, 'argExpr'), staticContext);

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -269,10 +269,7 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 			annotateTypeSwitchOperator(ast);
 
 		case 'quantifiedExpr':
-			// Variable amount of children from this AST node, solution: looping through them
-			for (let iterationCounter = 1; iterationCounter < ast.length; iterationCounter++) {
-				annotate(ast[iterationCounter] as IAST, staticContext);
-			}
+			astHelper.getChildren(ast, '*').map((a) => annotate(a, staticContext));
 			return annotateQuantifiedExpr(ast);
 
 		default:

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -165,7 +165,20 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 		// Context Item
 		case 'contextItemExpr':
 			return annotateContextItemExpr(ast);
-
+		case 'ifThenElseExpr': {
+			const ifClause = annotate(
+				astHelper.getFirstChild(astHelper.getFirstChild(ast, 'ifClause'), '*'),
+				staticContext
+			);
+			const thenClause = annotate(
+				astHelper.getFirstChild(astHelper.getFirstChild(ast, 'thenClause'), '*'),
+				staticContext
+			);
+			const elseClause = annotate(
+				astHelper.getFirstChild(astHelper.getFirstChild(ast, 'elseClause'), '*'),
+				staticContext
+			);
+		}
 		case 'instanceOfExpr': {
 			annotate(astHelper.getFirstChild(ast, 'argExpr'), staticContext);
 			annotate(astHelper.getFirstChild(ast, 'sequenceType'), staticContext);

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -10,6 +10,7 @@ import {
 } from './annotateCompareOperator';
 import { annotateFunctionCall } from './annotateFunctionCall';
 import { annotateLogicalOperator } from './annotateLogicalOperator';
+import { annotatePathExpr } from './annotatePathExpr';
 import { annotateRangeSequenceOperator } from './annotateRangeSequenceOperator';
 import { annotateSequenceOperator } from './annotateSequenceOperator';
 import { annotateSetOperator } from './annotateSetOperators';
@@ -146,6 +147,14 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 			annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, staticContext);
 			return annotateNodeCompare(ast);
 		}
+
+		// Path Expression
+		case 'pathExpr':
+			const root = astHelper.getFirstChild(ast, 'rootExpr');
+			if (root) annotate(root[1] as IAST, staticContext);
+			astHelper.getChildren(ast, 'stepExpr').map((arg) => annotate(arg, staticContext));
+			return annotatePathExpr(ast);
+
 		// Constant expressions
 		case 'integerConstantExpr':
 			const integerSequenceType = {

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -14,6 +14,7 @@ import { annotateRangeSequenceOperator } from './annotateRangeSequenceOperator';
 import { annotateSequenceOperator } from './annotateSequenceOperator';
 import { annotateSetOperator } from './annotateSetOperators';
 import { annotateStringConcatenateOperator } from './annotateStringConcatenateOperator';
+import { annotateTypeSwitchOperator } from './annotateTypeSwitchOperator';
 import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
 
 /**
@@ -90,7 +91,7 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 		// Sequences
 		case 'sequenceExpr':
 			const children = astHelper.getChildren(ast, '*');
-			children.map((arg) => annotate(arg, staticContext));
+			children.map((a) => annotate(a, staticContext));
 			return annotateSequenceOperator(ast, children.length);
 
 		// Set operations (union, intersect, except)
@@ -187,14 +188,14 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 			return annotateCastableOperator(ast);
 		case 'typeSwitchExpr':
 			const arg = annotate(astHelper.getFirstChild(ast, 'argExpr') as IAST, staticContext);
-			const clauses = (astHelper.getChildren(
-				ast,
-				'typeswitchExprCaseClause'
-			) as IAST[]).map((a) => annotate(a, staticContext));
+			const clauses = astHelper
+				.getChildren(ast, 'typeswitchExprCaseClause')
+				.map((a) => annotate(a, staticContext));
 			const defaultCase = annotate(
 				astHelper.getFirstChild(ast, 'typeSwitchExprDefaultClause') as IAST,
 				staticContext
 			);
+			annotateTypeSwitchOperator(ast);
 		default:
 			// Current node cannot be annotated, but maybe deeper ones can.
 			for (let i = 1; i < ast.length; i++) {

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -146,6 +146,10 @@ export function annotate(ast: IAST, staticContext: StaticContext): SequenceType 
 			annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, staticContext);
 			return annotateNodeCompare(ast);
 		}
+		case 'instanceOfExpr': {
+			annotate(astHelper.getFirstChild(ast, 'argExpr'), staticContext);
+			annotate(astHelper.getFirstChild(ast, 'sequenceType'), staticContext);
+		}
 		// Constant expressions
 		case 'integerConstantExpr':
 			const integerSequenceType = {

--- a/src/typeInference/annotateArrayConstructor.ts
+++ b/src/typeInference/annotateArrayConstructor.ts
@@ -1,6 +1,13 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
 
+/**
+ * Inserting the array type of multiplicity exactly one to the ast;
+ * as array return type of the array constructor is array.
+ *
+ * @param ast the AST to be annotated.
+ * @returns the inferred SequenceType
+ */
 export function annotateArrayConstructor(ast: IAST): SequenceType {
 	const seqType = {
 		type: ValueType.ARRAY,

--- a/src/typeInference/annotateArrayConstructor.ts
+++ b/src/typeInference/annotateArrayConstructor.ts
@@ -3,7 +3,7 @@ import astHelper, { IAST } from '../parsing/astHelper';
 
 /**
  * Inserting the array type of multiplicity exactly one to the ast;
- * as array return type of the array constructor is array.
+ * as the return type of the array constructor is array.
  *
  * @param ast the AST to be annotated.
  * @returns the inferred SequenceType

--- a/src/typeInference/annotateArrayConstructor.ts
+++ b/src/typeInference/annotateArrayConstructor.ts
@@ -1,0 +1,13 @@
+import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import astHelper, { IAST } from '../parsing/astHelper';
+
+export function annotateArrayConstructor(ast: IAST): SequenceType {
+	const seqType = {
+		type: ValueType.ARRAY,
+		mult: SequenceMultiplicity.EXACTLY_ONE,
+	};
+
+	astHelper.insertAttribute(ast, 'type', seqType);
+
+	return seqType;
+}

--- a/src/typeInference/annotateArrowExpr.ts
+++ b/src/typeInference/annotateArrowExpr.ts
@@ -1,5 +1,5 @@
-import StaticContext from '../expressions/StaticContext';
 import { SequenceType } from '../expressions/dataTypes/Value';
+import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
 
 /**
@@ -14,32 +14,31 @@ export function annotateArrowExpr(
 	ast: IAST,
 	staticContext: StaticContext
 ): SequenceType | undefined {
-    // We need the context to lookup the function information
-    if (!staticContext) return undefined;
+	// We need the context to lookup the function information
+	if (!staticContext) return undefined;
 
-    const func = astHelper.getFirstChild(ast, 'EQName');
+	const func = astHelper.getFirstChild(ast, 'EQName');
 
-    // There may be no name for the function
-    if (!func) {
-        return undefined;
-    }
+	// There may be no name for the function
+	if (!func) {
+		return undefined;
+	}
 
-    // Sometimes there is no prefix given, hence we need to check for that case and give an empty prefix
-    let functionName;
-    let functionPrefix;
-    if (func.length === 3) {
-        functionName = func[2];
-        functionPrefix = func[1];
-    }
-    else {
-        functionName = func[1];
-        functionPrefix = '';
-    }
+	// Sometimes there is no prefix given, hence we need to check for that case and give an empty prefix
+	let functionName;
+	let functionPrefix;
+	if (func.length === 3) {
+		functionName = func[2];
+		functionPrefix = func[1];
+	} else {
+		functionName = func[1];
+		functionPrefix = '';
+	}
 
-    const functionArguments = astHelper.getChildren(astHelper.getFirstChild(ast, 'arguments'), '*');
+	const functionArguments = astHelper.getChildren(astHelper.getFirstChild(ast, 'arguments'), '*');
 
-    // Lookup the namespace URI
-    const resolvedName = staticContext.resolveFunctionName(
+	// Lookup the namespace URI
+	const resolvedName = staticContext.resolveFunctionName(
 		{
 			localName: functionName as string,
 			prefix: functionPrefix['prefix'] as string,
@@ -47,16 +46,16 @@ export function annotateArrowExpr(
 		functionArguments.length
 	);
 
-    if (!resolvedName) return undefined;
+	if (!resolvedName) return undefined;
 
-    // Lookup the function properties (return type)
-    const functionProps = staticContext.lookupFunction(
+	// Lookup the function properties (return type)
+	const functionProps = staticContext.lookupFunction(
 		resolvedName.namespaceURI,
 		resolvedName.localName,
 		functionArguments.length
 	);
 
-    if (!functionProps) return undefined;
+	if (!functionProps) return undefined;
 
 	astHelper.insertAttribute(ast, 'type', functionProps.returnType);
 	return functionProps.returnType;

--- a/src/typeInference/annotateArrowExpr.ts
+++ b/src/typeInference/annotateArrowExpr.ts
@@ -1,0 +1,63 @@
+import StaticContext from '../expressions/StaticContext';
+import { SequenceType } from '../expressions/dataTypes/Value';
+import astHelper, { IAST } from '../parsing/astHelper';
+
+/**
+ * Annotate the arrowExpr by extracting the function info from the static context
+ * and inserting the return type to the AST as new attribute `type`.
+ *
+ * @param ast the AST to be annotated.
+ * @param staticContext from witch the function info is extracted.
+ * @returns the inferred type or `undefined` when function properties cannot be inferred.
+ */
+export function annotateArrowExpr(
+	ast: IAST,
+	staticContext: StaticContext
+): SequenceType | undefined {
+    // We need the context to lookup the function information
+    if (!staticContext) return undefined;
+
+    const func = astHelper.getFirstChild(ast, 'EQName');
+
+    // There may be no name for the function
+    if (!func) {
+        return undefined;
+    }
+
+    // Sometimes there is no prefix given, hence we need to check for that case and give an empty prefix
+    let functionName;
+    let functionPrefix;
+    if (func.length === 3) {
+        functionName = func[2];
+        functionPrefix = func[1];
+    }
+    else {
+        functionName = func[1];
+        functionPrefix = '';
+    }
+
+    const functionArguments = astHelper.getChildren(astHelper.getFirstChild(ast, 'arguments'), '*');
+
+    // Lookup the namespace URI
+    const resolvedName = staticContext.resolveFunctionName(
+		{
+			localName: functionName as string,
+			prefix: functionPrefix['prefix'] as string,
+		},
+		functionArguments.length
+	);
+
+    if (!resolvedName) return undefined;
+
+    // Lookup the function properties (return type)
+    const functionProps = staticContext.lookupFunction(
+		resolvedName.namespaceURI,
+		resolvedName.localName,
+		functionArguments.length
+	);
+
+    if (!functionProps) return undefined;
+
+	astHelper.insertAttribute(ast, 'type', functionProps.returnType);
+	return functionProps.returnType;
+}

--- a/src/typeInference/annotateArrowExpr.ts
+++ b/src/typeInference/annotateArrowExpr.ts
@@ -25,13 +25,13 @@ export function annotateArrowExpr(
 	}
 
 	// Sometimes there is no prefix given, hence we need to check for that case and give an empty prefix
-	let functionName;
-	let functionPrefix;
+	let functionName: string;
+	let functionPrefix: string;
 	if (func.length === 3) {
-		functionName = func[2];
-		functionPrefix = func[1];
+		functionName = func[2] as string;
+		functionPrefix = func[1] as string;
 	} else {
-		functionName = func[1];
+		functionName = func[1] as string;
 		functionPrefix = '';
 	}
 
@@ -40,7 +40,7 @@ export function annotateArrowExpr(
 	// Lookup the namespace URI
 	const resolvedName = staticContext.resolveFunctionName(
 		{
-			localName: functionName as string,
+			localName: functionName,
 			prefix: functionPrefix['prefix'] as string,
 		},
 		functionArguments.length

--- a/src/typeInference/annotateBinaryOperator.ts
+++ b/src/typeInference/annotateBinaryOperator.ts
@@ -1,4 +1,4 @@
-import { SequenceType, sequenceTypeToString } from '../expressions/dataTypes/Value';
+import { SequenceType, sequenceTypeToString, ValueType } from '../expressions/dataTypes/Value';
 import {
 	generateBinaryOperatorType,
 	getBinaryPrefabOperator,
@@ -27,6 +27,9 @@ export function annotateBinOp(
 	if (!left || !right) {
 		return undefined;
 	}
+
+	// TODO: Fix this hack (pathExpr returns a node in 1 case, which cannot be added to an integer)
+	if (left.type === ValueType.NODE || right.type === ValueType.NODE) return undefined;
 
 	const funcData = generateBinaryOperatorType(operator, left.type, right.type);
 

--- a/src/typeInference/annotateContextItemExpr.ts
+++ b/src/typeInference/annotateContextItemExpr.ts
@@ -1,5 +1,5 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
-import astHelper, { IAST } from '../parsing/astHelper';
+import { IAST } from '../parsing/astHelper';
 
 /**
  * A context item expression evaluates to the context item. Hence the type that is returned is the one from the context item.
@@ -7,6 +7,6 @@ import astHelper, { IAST } from '../parsing/astHelper';
  * @returns the type of the context item.
  */
 export function annotateContextItemExpr(ast: IAST): SequenceType | undefined {
-	const typeNode = astHelper.followPath(ast, ['type']);
-	return typeNode ? (typeNode[1] as SequenceType) : undefined;
+	// TODO: What type should be returned here?
+	return undefined;
 }

--- a/src/typeInference/annotateContextItemExpr.ts
+++ b/src/typeInference/annotateContextItemExpr.ts
@@ -1,0 +1,12 @@
+import { SequenceType } from '../expressions/dataTypes/Value';
+import astHelper, { IAST } from '../parsing/astHelper';
+
+/**
+ * A context item expression evaluates to the context item. Hence the type that is returned is the one from the context item.
+ * @param ast the AST to be annotated.
+ * @returns the type of the context item.
+ */
+export function annotateContextItemExpr(ast: IAST): SequenceType | undefined {
+	const typeNode = astHelper.followPath(ast, ['type']);
+	return typeNode ? (typeNode[1] as SequenceType) : undefined;
+}

--- a/src/typeInference/annotateContextItemExpr.ts
+++ b/src/typeInference/annotateContextItemExpr.ts
@@ -3,6 +3,7 @@ import { IAST } from '../parsing/astHelper';
 
 /**
  * A context item expression evaluates to the context item. Hence the type that is returned is the one from the context item.
+ *
  * @param ast the AST to be annotated.
  * @returns the type of the context item.
  */

--- a/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
+++ b/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
@@ -1,6 +1,6 @@
-import { SequenceType } from '../expressions/dataTypes/Value';
+import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import StaticContext from '../expressions/StaticContext';
-import { IAST } from '../parsing/astHelper';
+import astHelper, { IAST } from '../parsing/astHelper';
 
 /**
  * At this moment there is no way to infer the return type of this function as
@@ -18,5 +18,13 @@ export function annotateDynamicFunctionInvocationExpr(
 	functionItem: SequenceType,
 	args: SequenceType
 ): SequenceType {
-	return undefined;
+	// return undefined;
+	const seqType = {
+		type: ValueType.ITEM,
+		mult: SequenceMultiplicity.ZERO_OR_MORE,
+	};
+
+	astHelper.insertAttribute(ast, 'type', seqType);
+
+	return seqType;
 }

--- a/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
+++ b/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
@@ -3,7 +3,7 @@ import StaticContext from '../expressions/StaticContext';
 import { IAST } from '../parsing/astHelper';
 
 /**
- * At this moment there is no way to infre the return type of this function as
+ * At this moment there is no way to infer the return type of this function as
  * this would require the query to be executed. Therefore, the it would return undefined.
  *
  * @param ast The ast we need to check the type of.

--- a/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
+++ b/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
@@ -1,6 +1,6 @@
-import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import { SequenceType } from '../expressions/dataTypes/Value';
 import StaticContext from '../expressions/StaticContext';
-import astHelper, { IAST } from '../parsing/astHelper';
+import { IAST } from '../parsing/astHelper';
 
 /**
  * At this moment there is no way to infer the return type of this function as
@@ -18,13 +18,5 @@ export function annotateDynamicFunctionInvocationExpr(
 	functionItem: SequenceType,
 	args: SequenceType
 ): SequenceType {
-	// return undefined;
-	const seqType = {
-		type: ValueType.ITEM,
-		mult: SequenceMultiplicity.ZERO_OR_MORE,
-	};
-
-	astHelper.insertAttribute(ast, 'type', seqType);
-
-	return seqType;
+	return undefined;
 }

--- a/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
+++ b/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
@@ -1,0 +1,22 @@
+import { SequenceType } from '../expressions/dataTypes/Value';
+import StaticContext from '../expressions/StaticContext';
+import { IAST } from '../parsing/astHelper';
+
+/**
+ * At this moment there is no way to infre the return type of this function as
+ * this would require the query to be executed. Therefore, the it would return undefined.
+ *
+ * @param ast The ast we need to check the type of.
+ * @param staticContext The context in which it is evaluated.
+ * @param functionItem the function body itself.
+ * @param args the arguments with which the function is called.
+ * @returns The type of the ast.
+ */
+export function annotateDynamicFunctionInvocationExpr(
+	ast: IAST,
+	staticContext: StaticContext,
+	functionItem: SequenceType,
+	args: SequenceType
+): SequenceType {
+	return undefined;
+}

--- a/src/typeInference/annotateIfThenElseExpr.ts
+++ b/src/typeInference/annotateIfThenElseExpr.ts
@@ -1,0 +1,12 @@
+import { SequenceType } from '../expressions/dataTypes/Value';
+import { IAST } from '../parsing/astHelper';
+
+export function annotateIfThenElseExpr(
+	ast: IAST,
+	ifClause: SequenceType,
+	elseClause: SequenceType,
+	thenClause: SequenceType
+): SequenceType {
+	if (elseClause === thenClause) return elseClause;
+	else return undefined;
+}

--- a/src/typeInference/annotateIfThenElseExpr.ts
+++ b/src/typeInference/annotateIfThenElseExpr.ts
@@ -1,6 +1,15 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
 
+/**
+ * Checks the type and multiplicity of else clause and then clause
+ * and inserts the type to the ast as an attribute if they match.
+ *
+ * @param ast the AST to be annotated.
+ * @param elseClause the elseClause, uses type data of this param to ast.
+ * @param thenClause the thenClause.
+ * @returns the type of the context item.
+ */
 export function annotateIfThenElseExpr(
 	ast: IAST,
 	elseClause: SequenceType,

--- a/src/typeInference/annotateIfThenElseExpr.ts
+++ b/src/typeInference/annotateIfThenElseExpr.ts
@@ -1,12 +1,17 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
-import { IAST } from '../parsing/astHelper';
+import astHelper, { IAST } from '../parsing/astHelper';
 
 export function annotateIfThenElseExpr(
 	ast: IAST,
-	ifClause: SequenceType,
 	elseClause: SequenceType,
 	thenClause: SequenceType
 ): SequenceType {
-	if (elseClause === thenClause) return elseClause;
-	else return undefined;
+	if (!elseClause || !thenClause) {
+		return undefined;
+	}
+	if (elseClause.type === thenClause.type && elseClause.mult === thenClause.mult) {
+		astHelper.insertAttribute(ast, 'type', elseClause);
+		return elseClause;
+	}
+	return undefined;
 }

--- a/src/typeInference/annotateInstanceOfExpr.ts
+++ b/src/typeInference/annotateInstanceOfExpr.ts
@@ -1,0 +1,16 @@
+// argExpr
+// sequenceType
+
+import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import astHelper, { IAST } from '../parsing/astHelper';
+
+export function annotateInstanceOfExpr(ast: IAST): SequenceType {
+	const seqType = {
+		type: ValueType.XSBOOLEAN,
+		mult: SequenceMultiplicity.EXACTLY_ONE,
+	};
+
+	astHelper.insertAttribute(ast, 'type', seqType);
+
+	return seqType;
+}

--- a/src/typeInference/annotateInstanceOfExpr.ts
+++ b/src/typeInference/annotateInstanceOfExpr.ts
@@ -1,9 +1,13 @@
-// argExpr
-// sequenceType
-
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
 
+/**
+ * Insert type boolean multiplicity exactly one the type to the ast
+ * as an attribute, since instance of expression evaluates to a boolean.
+ *
+ * @param ast the AST to be annotated.
+ * @returns the type of the context item.
+ */
 export function annotateInstanceOfExpr(ast: IAST): SequenceType {
 	const seqType = {
 		type: ValueType.XSBOOLEAN,

--- a/src/typeInference/annotateMapConstructor.ts
+++ b/src/typeInference/annotateMapConstructor.ts
@@ -1,6 +1,13 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
 
+/**
+ * Inserting the map type of multiplicity exactly one to the ast;
+ * as the return type of the map constructor is map.
+ *
+ * @param ast the AST to be annotated.
+ * @returns the inferred SequenceType
+ */
 export function annotateMapConstructor(ast: IAST): SequenceType {
 	const seqType = {
 		type: ValueType.MAP,

--- a/src/typeInference/annotateMapConstructor.ts
+++ b/src/typeInference/annotateMapConstructor.ts
@@ -1,0 +1,12 @@
+import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import astHelper, { IAST } from '../parsing/astHelper';
+
+export function annotateMapConstructor(ast: IAST): SequenceType {
+	const seqType = {
+		type: ValueType.MAP,
+		mult: SequenceMultiplicity.EXACTLY_ONE,
+	};
+
+	astHelper.insertAttribute(ast, 'type', seqType);
+	return seqType;
+}

--- a/src/typeInference/annotateNamedFunctionRef.ts
+++ b/src/typeInference/annotateNamedFunctionRef.ts
@@ -1,4 +1,4 @@
-import { SequenceType } from '../expressions/dataTypes/Value';
+import { SequenceType, ValueType, SequenceMultiplicity } from '../expressions/dataTypes/Value';
 import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
 
@@ -14,5 +14,38 @@ export function annotateNamedFunctionRef(
 	ast: IAST,
 	staticContext: StaticContext
 ): SequenceType | undefined {
-	return undefined;
+	// Can't find info about the function without the context.
+	if (!staticContext) return undefined;
+
+	// Get qualified function name
+	const functionQName = astHelper.getQName(astHelper.getFirstChild(ast, 'functionName'));
+
+	// Spice the components up
+	let localName = functionQName[0];
+	let namespaceURI = functionQName[1];
+	const prefix = functionQName[2];
+
+	const arity = astHelper.getFirstChild(ast, 'integerConstantExpr')[1][1];
+
+	// If there is no namespace URI, resolve the function name
+	if (!namespaceURI) {
+		const functionName = staticContext.resolveFunctionName({ localName, prefix }, arity);
+
+		if (!functionName) {
+			return undefined;
+		}
+
+		localName = functionName.localName;
+		namespaceURI = functionName.namespaceURI;
+	}
+
+	// With all components there, look up the function properties
+	const functionProperties = staticContext.lookupFunction(namespaceURI, localName, arity) || null;
+
+	// If there are no function properties, there is no type inference
+	if (!functionProperties) return undefined;
+
+	//Insert the type info into the AST and return
+	astHelper.insertAttribute(ast, 'type', functionProperties.returnType);
+	return functionProperties.returnType;
 }

--- a/src/typeInference/annotateNamedFunctionRef.ts
+++ b/src/typeInference/annotateNamedFunctionRef.ts
@@ -1,4 +1,4 @@
-import { SequenceType, ValueType, SequenceMultiplicity } from '../expressions/dataTypes/Value';
+import { SequenceType } from '../expressions/dataTypes/Value';
 import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
 
@@ -45,7 +45,7 @@ export function annotateNamedFunctionRef(
 	// If there are no function properties, there is no type inference
 	if (!functionProperties) return undefined;
 
-	//Insert the type info into the AST and return
+	// Insert the type info into the AST and return
 	astHelper.insertAttribute(ast, 'type', functionProperties.returnType);
 	return functionProperties.returnType;
 }

--- a/src/typeInference/annotateNamedFunctionRef.ts
+++ b/src/typeInference/annotateNamedFunctionRef.ts
@@ -1,0 +1,18 @@
+import { SequenceType } from '../expressions/dataTypes/Value';
+import StaticContext from '../expressions/StaticContext';
+import astHelper, { IAST } from '../parsing/astHelper';
+
+/**
+ * Annotate named function references by extracting the function info from the static context
+ * and inserting the return type to the AST as new attribute `type`.
+ *
+ * @param ast the AST to be annotated.
+ * @param staticContext from witch the function info is extracted.
+ * @returns the inferred type or `undefined` when the named function reference type cannot be inferred.
+ */
+export function annotateNamedFunctionRef(
+	ast: IAST,
+	staticContext: StaticContext
+): SequenceType | undefined {
+	return undefined;
+}

--- a/src/typeInference/annotatePathExpr.ts
+++ b/src/typeInference/annotatePathExpr.ts
@@ -1,0 +1,12 @@
+import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import astHelper, { IAST } from '../parsing/astHelper';
+
+export function annotatePathExpr(ast: IAST): SequenceType {
+	const seqType = {
+		type: ValueType.NODE,
+		mult: SequenceMultiplicity.ZERO_OR_MORE,
+	};
+
+	astHelper.insertAttribute(ast, 'type', seqType);
+	return seqType;
+}

--- a/src/typeInference/annotatePathExpr.ts
+++ b/src/typeInference/annotatePathExpr.ts
@@ -1,6 +1,13 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
 
+/**
+ * Inserting the node type of multiplicity zero or more to the ast;
+ * as the path expr evaluates to node.
+ *
+ * @param ast the AST to be annotated.
+ * @returns the inferred SequenceType
+ */
 export function annotatePathExpr(ast: IAST): SequenceType {
 	const seqType = {
 		type: ValueType.NODE,

--- a/src/typeInference/annotateQuantifiedExpr.ts
+++ b/src/typeInference/annotateQuantifiedExpr.ts
@@ -1,0 +1,22 @@
+import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import astHelper, { IAST } from '../parsing/astHelper';
+
+/**
+ *
+ * Annotate the ast by inserting boolean sequence type of exactly one multiplicity.
+ * Quantified Expression evaluates if a statement satisfies the quantifier;
+ * therefore its value is a boolean.
+ *
+ * @param ast the ast node to be annotated.
+ * @returns the annotated sequence type.
+ */
+export function annotateQuantifiedExpr(ast: IAST): SequenceType {
+	const seqType = {
+		type: ValueType.XSBOOLEAN,
+		mult: SequenceMultiplicity.EXACTLY_ONE,
+	};
+
+	astHelper.insertAttribute(ast, 'type', seqType);
+
+	return seqType;
+}

--- a/src/typeInference/annotateQuantifiedExpr.ts
+++ b/src/typeInference/annotateQuantifiedExpr.ts
@@ -2,7 +2,6 @@ import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/da
 import astHelper, { IAST } from '../parsing/astHelper';
 
 /**
- *
  * Annotate the ast by inserting boolean sequence type of exactly one multiplicity.
  * Quantified Expression evaluates if a statement satisfies the quantifier;
  * therefore its value is a boolean.

--- a/src/typeInference/annotateSimpleMapExpr.ts
+++ b/src/typeInference/annotateSimpleMapExpr.ts
@@ -1,0 +1,12 @@
+import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import astHelper, { IAST } from '../parsing/astHelper';
+
+export function annotateSimpleMapExpr(ast: IAST): SequenceType {
+	const seqType = {
+		type: ValueType.MAP,
+		mult: SequenceMultiplicity.EXACTLY_ONE,
+	};
+
+	astHelper.insertAttribute(ast, 'type', seqType);
+	return seqType;
+}

--- a/src/typeInference/annotateSimpleMapExpr.ts
+++ b/src/typeInference/annotateSimpleMapExpr.ts
@@ -1,6 +1,13 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
 
+/**
+ * Inserting the map type of multiplicity exactly one to the ast;
+ * as the simple map expr evaluates to map.
+ *
+ * @param ast the AST to be annotated.
+ * @returns the inferred SequenceType
+ */
 export function annotateSimpleMapExpr(ast: IAST): SequenceType {
 	const seqType = {
 		type: ValueType.MAP,

--- a/src/typeInference/annotateTypeSwitchOperator.ts
+++ b/src/typeInference/annotateTypeSwitchOperator.ts
@@ -1,0 +1,7 @@
+import { SequenceType } from '../expressions/dataTypes/Value';
+import { IAST } from '../parsing/astHelper';
+
+// TODO: Implement this function, the docs don't mention it so we don't know the return types.
+function annotateTypeSwitchOperator(ast: IAST): SequenceType {
+	return undefined;
+}

--- a/src/typeInference/annotateTypeSwitchOperator.ts
+++ b/src/typeInference/annotateTypeSwitchOperator.ts
@@ -1,7 +1,7 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
 import { IAST } from '../parsing/astHelper';
 
-// TODO: Implement this function, the docs don't mention it so we don't know the return types.
+// TODO: Annotation not yet implemented. The docs don't mention it so we don't know the return types.
 export function annotateTypeSwitchOperator(ast: IAST): SequenceType {
 	return undefined;
 }

--- a/src/typeInference/annotateTypeSwitchOperator.ts
+++ b/src/typeInference/annotateTypeSwitchOperator.ts
@@ -2,6 +2,6 @@ import { SequenceType } from '../expressions/dataTypes/Value';
 import { IAST } from '../parsing/astHelper';
 
 // TODO: Implement this function, the docs don't mention it so we don't know the return types.
-function annotateTypeSwitchOperator(ast: IAST): SequenceType {
+export function annotateTypeSwitchOperator(ast: IAST): SequenceType {
 	return undefined;
 }

--- a/src/typeInference/annotateUnaryLookup.ts
+++ b/src/typeInference/annotateUnaryLookup.ts
@@ -1,6 +1,6 @@
 import { IAST } from '../parsing/astHelper';
 
+// TODO: Annotation not yet implemented. How to lookup the NCName and get the type to be returned.
 export function annotateUnaryLookup(ast: IAST, ncName: IAST): undefined {
-	// TODO: How to lookup the NCName and get the type to be returned.
 	return undefined;
 }

--- a/src/typeInference/annotateUnaryLookup.ts
+++ b/src/typeInference/annotateUnaryLookup.ts
@@ -1,0 +1,6 @@
+import { IAST } from '../parsing/astHelper';
+
+export function annotateUnaryLookup(ast: IAST, ncName: IAST): undefined {
+	// TODO: How to lookup the NCName and get the type to be returned.
+	return undefined;
+}

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -72,6 +72,7 @@ describe('Annotating cast expressions', () => {
 describe('Annotate quantifiedExpr', () => {
 	it('quantifiedExpr', () =>
 		assertValueType('every $x in true() satisfies $x', ValueType.XSBOOLEAN));
+});
 
 describe('Annotating ifThenElse expressions', () => {
 	it('ifThenElse type is known', () =>

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -64,3 +64,8 @@ describe('Annotating cast expressions', () => {
 	it('unknown child cast expression', () =>
 		assertValueType('$x cast as xs:integer', ValueType.XSINTEGER));
 });
+
+describe('Annotate maps', () => {
+	it('mapConstructor', () => assertValueType('map{a:1, b:2}', ValueType.MAP));
+	it('simpleMapExpr', () => assertValueType('$a ! ( //b)', ValueType.MAP));
+});

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -64,3 +64,8 @@ describe('Annotating cast expressions', () => {
 	it('unknown child cast expression', () =>
 		assertValueType('$x cast as xs:integer', ValueType.XSINTEGER));
 });
+
+describe('Annotate quantifiedExpr', () => {
+	it('quantifiedExpr', () =>
+		assertValueType('every $x in true() satisfies $x', ValueType.XSBOOLEAN));
+});

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -10,7 +10,11 @@ function assertValueType(expression: string, expectedType: ValueType) {
 
 	const queryBody = astHelper.followPath(ast, ['mainModule', 'queryBody']);
 	const resultType = astHelper.getAttribute(queryBody[1] as IAST, 'type') as SequenceType;
-	chai.assert.deepEqual(resultType.type, expectedType);
+	if (!resultType) {
+		chai.assert.isTrue(!expectedType);
+	} else {
+		chai.assert.deepEqual(resultType.type, expectedType);
+	}
 }
 
 describe('Annotating constants', () => {
@@ -63,4 +67,10 @@ describe('Annotating cast expressions', () => {
 	it('simple cast expression', () => assertValueType('5 cast as xs:double', ValueType.XSDOUBLE));
 	it('unknown child cast expression', () =>
 		assertValueType('$x cast as xs:integer', ValueType.XSINTEGER));
+});
+
+describe('Annotating ifThenElse expressions', () => {
+	it('ifThenElse type is known', () =>
+		assertValueType('if (3) then 3 else 5', ValueType.XSINTEGER));
+	it('ifThenElse type is not known', () => assertValueType('if (3) then "hello" else 5', null));
 });


### PR DESCRIPTION
## Description

Annotation on other nodes (All things left in the 58)

Closes #58

## Changes

1. Changed compileAstToExpression to include the type param
2. Added files that handles different types of nodes
3. Added switches cases to call these functions and annotate them (and their children)

## Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

## How Many Approvals?

* Approval of all (Controversial changes that change the entire project)