### PR TITLE
93 coverage metric

### DIFF
--- a/src/evaluateUpdatingExpression.ts
+++ b/src/evaluateUpdatingExpression.ts
@@ -69,6 +69,7 @@ export default async function evaluateUpdatingExpression(
 				debug: !!options['debug'],
 				disableCache: !!options['disableCache'],
 				annotateAst: !!options['annotateAst'],
+				logUnannotatedQueries: !!options['logUnannotatedQueries'],
 			}
 		);
 		dynamicContext = context.dynamicContext;

--- a/src/evaluateUpdatingExpressionSync.ts
+++ b/src/evaluateUpdatingExpressionSync.ts
@@ -57,6 +57,7 @@ export default function evaluateUpdatingExpressionSync<
 				debug: !!options['debug'],
 				disableCache: !!options['disableCache'],
 				annotateAst: !!options['annotateAst'],
+				logUnannotatedQueries: !!options['logUnannotatedQueries'],
 			}
 		);
 		dynamicContext = context.dynamicContext;

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -158,6 +158,7 @@ const evaluateXPath = <TNode extends Node, TReturnType extends keyof IReturnType
 				debug: !!options['debug'],
 				disableCache: !!options['disableCache'],
 				annotateAst: !!options['annotateAst'],
+				logUnannotatedQueries: !!options['logUnannotatedQueries'],
 			}
 		);
 		dynamicContext = context.dynamicContext;

--- a/src/evaluationUtils/buildEvaluationContext.ts
+++ b/src/evaluationUtils/buildEvaluationContext.ts
@@ -77,6 +77,7 @@ export default function buildEvaluationContext(
 		annotateAst: boolean;
 		debug: boolean;
 		disableCache: boolean;
+		logUnannotatedQueries: boolean;
 	}
 ): {
 	dynamicContext: DynamicContext;

--- a/src/expressions/functions/builtInFunctions_fontoxpath.ts
+++ b/src/expressions/functions/builtInFunctions_fontoxpath.ts
@@ -64,8 +64,8 @@ const fontoxpathEvaluate: FunctionDefinitionType = (
 				if (executionParameters.annotateAst) {
 					annotateAst(ast, {
 						staticContext: innerStaticContext,
+						totalNodes: 0,
 						totalAnnotated: [],
-						totalNodes: [],
 					});
 				}
 

--- a/src/expressions/functions/builtInFunctions_fontoxpath.ts
+++ b/src/expressions/functions/builtInFunctions_fontoxpath.ts
@@ -62,7 +62,11 @@ const fontoxpathEvaluate: FunctionDefinitionType = (
 				});
 
 				if (executionParameters.annotateAst) {
-					annotateAst(ast, innerStaticContext);
+					annotateAst(ast, {
+						staticContext: innerStaticContext,
+						totalAnnotated: [],
+						totalNodes: [],
+					});
 				}
 
 				const prolog = astHelper.followPath(ast, ['mainModule', 'prolog']);

--- a/src/expressions/functions/builtInFunctions_fontoxpath.ts
+++ b/src/expressions/functions/builtInFunctions_fontoxpath.ts
@@ -64,8 +64,6 @@ const fontoxpathEvaluate: FunctionDefinitionType = (
 				if (executionParameters.annotateAst) {
 					annotateAst(ast, {
 						staticContext: innerStaticContext,
-						totalNodes: 0,
-						totalAnnotated: [],
 					});
 				}
 

--- a/src/expressions/path/ContextItemExpression.ts
+++ b/src/expressions/path/ContextItemExpression.ts
@@ -1,5 +1,7 @@
 import sequenceFactory from '../dataTypes/sequenceFactory';
 import { SequenceType } from '../dataTypes/Value';
+import DynamicContext from '../DynamicContext';
+import ExecutionParameters from '../ExecutionParameters';
 import Expression, { RESULT_ORDERINGS } from '../Expression';
 import Specificity from '../Specificity';
 
@@ -16,7 +18,7 @@ class ContextItemExpression extends Expression {
 		);
 	}
 
-	public evaluate(dynamicContext, _executionParameters) {
+	public evaluate(dynamicContext: DynamicContext, _executionParameters: ExecutionParameters) {
 		if (dynamicContext.contextItem === null) {
 			throw new Error(
 				'XPDY0002: context is absent, it needs to be present to use the "." operator'

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ function parseXPath(xpathString: string) {
 
 	const ast = parseExpression(xpathString, { allowXQuery: false });
 
-	annotateAst(ast, { staticContext: undefined, totalAnnotated: [], totalNodes: 0 });
+	annotateAst(ast, { staticContext: undefined });
 
 	const queryBody = astHelper.followPath(ast, ['mainModule', 'queryBody', '*']);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,8 @@ import {
 	Text,
 } from './types/Types';
 
+evaluateXPath('map:contains(map{}, "a")');
+
 function parseXPath(xpathString: string) {
 	const cachedExpression = getAnyStaticCompilationResultFromCache(xpathString, 'XPath', false);
 	if (cachedExpression) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,8 +60,6 @@ import {
 	Text,
 } from './types/Types';
 
-evaluateXPath('(() except ())');
-
 function parseXPath(xpathString: string) {
 	const cachedExpression = getAnyStaticCompilationResultFromCache(xpathString, 'XPath', false);
 	if (cachedExpression) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ import {
 	Text,
 } from './types/Types';
 
-evaluateXPath('+"something"');
+evaluateXPath('(() except ())');
 
 function parseXPath(xpathString: string) {
 	const cachedExpression = getAnyStaticCompilationResultFromCache(xpathString, 'XPath', false);

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,8 @@ import {
 	Text,
 } from './types/Types';
 
+evaluateXPath('+"something"');
+
 function parseXPath(xpathString: string) {
 	const cachedExpression = getAnyStaticCompilationResultFromCache(xpathString, 'XPath', false);
 	if (cachedExpression) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ function parseXPath(xpathString: string) {
 
 	const ast = parseExpression(xpathString, { allowXQuery: false });
 
-	annotateAst(ast);
+	annotateAst(ast, { staticContext: undefined, totalAnnotated: [], totalNodes: [] });
 
 	const queryBody = astHelper.followPath(ast, ['mainModule', 'queryBody', '*']);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ function parseXPath(xpathString: string) {
 
 	const ast = parseExpression(xpathString, { allowXQuery: false });
 
-	annotateAst(ast, { staticContext: undefined, totalAnnotated: [], totalNodes: [] });
+	annotateAst(ast, { staticContext: undefined, totalAnnotated: [], totalNodes: 0 });
 
 	const queryBody = astHelper.followPath(ast, ['mainModule', 'queryBody', '*']);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,8 +60,6 @@ import {
 	Text,
 } from './types/Types';
 
-evaluateXPath('map:contains(map{}, "a")');
-
 function parseXPath(xpathString: string) {
 	const cachedExpression = getAnyStaticCompilationResultFromCache(xpathString, 'XPath', false);
 	if (cachedExpression) {

--- a/src/parseScript.ts
+++ b/src/parseScript.ts
@@ -165,7 +165,7 @@ export default function parseScript<TElement extends Element>(
 	});
 
 	if (options.annotateAst) {
-		annotateAst(ast, { staticContext: undefined, totalNodes: [], totalAnnotated: [] });
+		annotateAst(ast, { staticContext: undefined, totalNodes: 0, totalAnnotated: [] });
 	}
 
 	return parseNode(documentWriter, simpleNodesFactory, ast, null) as TElement;

--- a/src/parseScript.ts
+++ b/src/parseScript.ts
@@ -165,7 +165,7 @@ export default function parseScript<TElement extends Element>(
 	});
 
 	if (options.annotateAst) {
-		annotateAst(ast);
+		annotateAst(ast, { staticContext: undefined, totalNodes: [], totalAnnotated: [] });
 	}
 
 	return parseNode(documentWriter, simpleNodesFactory, ast, null) as TElement;

--- a/src/parseScript.ts
+++ b/src/parseScript.ts
@@ -165,7 +165,7 @@ export default function parseScript<TElement extends Element>(
 	});
 
 	if (options.annotateAst) {
-		annotateAst(ast, { staticContext: undefined, totalNodes: 0, totalAnnotated: [] });
+		annotateAst(ast, { staticContext: undefined });
 	}
 
 	return parseNode(documentWriter, simpleNodesFactory, ast, null) as TElement;

--- a/src/parsing/staticallyCompileXPath.ts
+++ b/src/parsing/staticallyCompileXPath.ts
@@ -85,6 +85,18 @@ export default function staticallyCompileXPath(
 			processProlog(prolog, rootStaticContext);
 		}
 
+		if (compilationOptions.annotateAst) {
+			if (
+				annotateAst(ast, {
+					staticContext: rootStaticContext,
+					totalNodes: 0,
+					totalAnnotated: [],
+				}) < 0.5
+			) {
+				console.error(xpathString);
+			}
+		}
+
 		expression = compileAstToExpression(queryBodyContents, compilationOptions);
 	}
 

--- a/src/parsing/staticallyCompileXPath.ts
+++ b/src/parsing/staticallyCompileXPath.ts
@@ -60,7 +60,11 @@ export default function staticallyCompileXPath(
 		const ast = parseExpression(xpathString, compilationOptions);
 
 		if (compilationOptions.annotateAst) {
-			annotateAst(ast, rootStaticContext);
+			annotateAst(ast, {
+				staticContext: rootStaticContext,
+				totalAnnotated: [],
+				totalNodes: [],
+			});
 		}
 
 		const mainModule = astHelper.getFirstChild(ast, 'mainModule');

--- a/src/parsing/staticallyCompileXPath.ts
+++ b/src/parsing/staticallyCompileXPath.ts
@@ -62,8 +62,8 @@ export default function staticallyCompileXPath(
 		if (compilationOptions.annotateAst) {
 			annotateAst(ast, {
 				staticContext: rootStaticContext,
+				totalNodes: 0,
 				totalAnnotated: [],
-				totalNodes: [],
 			});
 		}
 

--- a/src/parsing/staticallyCompileXPath.ts
+++ b/src/parsing/staticallyCompileXPath.ts
@@ -62,8 +62,6 @@ export default function staticallyCompileXPath(
 		if (compilationOptions.annotateAst) {
 			annotateAst(ast, {
 				staticContext: rootStaticContext,
-				totalNodes: 0,
-				totalAnnotated: [],
 			});
 		}
 
@@ -86,16 +84,14 @@ export default function staticallyCompileXPath(
 		}
 
 		if (compilationOptions.annotateAst) {
-			const score = annotateAst(ast, {
+			annotateAst(ast, {
 				staticContext: rootStaticContext,
-				totalNodes: 0,
-				totalAnnotated: [],
 			});
 
 			const type = astHelper.getAttribute(queryBodyContents, 'type');
 
 			if (!type) {
-				console.error(score + ' | ' + xpathString);
+				console.error(xpathString);
 			}
 		}
 

--- a/src/parsing/staticallyCompileXPath.ts
+++ b/src/parsing/staticallyCompileXPath.ts
@@ -86,14 +86,16 @@ export default function staticallyCompileXPath(
 		}
 
 		if (compilationOptions.annotateAst) {
-			if (
-				annotateAst(ast, {
-					staticContext: rootStaticContext,
-					totalNodes: 0,
-					totalAnnotated: [],
-				}) < 0.5
-			) {
-				console.error(xpathString);
+			const score = annotateAst(ast, {
+				staticContext: rootStaticContext,
+				totalNodes: 0,
+				totalAnnotated: [],
+			});
+
+			const type = astHelper.getAttribute(queryBodyContents, 'type');
+
+			if (!type) {
+				console.error(score + ' | ' + xpathString);
 			}
 		}
 

--- a/src/parsing/staticallyCompileXPath.ts
+++ b/src/parsing/staticallyCompileXPath.ts
@@ -96,6 +96,7 @@ export default function staticallyCompileXPath(
 				if (totalNodes !== annotatedNodes) {
 					// We are logging an error here so we can easily pipe the list of all failed queries into a file
 					// Example: `npm run test 2> failedQueries.txt`
+					// tslint:disable-next-line:no-console
 					console.error(xpathString);
 				}
 			}

--- a/src/parsing/xpath.pegjs
+++ b/src/parsing/xpath.pegjs
@@ -1150,7 +1150,7 @@ InlineFunctionExpr
 
 // 170
 MapConstructor
- = "map" _ "{" _ entries:(first:MapConstructorEntry rest:(_ "," _ e:MapConstructorEntry {return e})*{return [first].concat(rest)})? _ "}" {return ["mapConstructor"].concat(entries)}
+ = "map" _ "{" _ entries:(first:MapConstructorEntry rest:(_ "," _ e:MapConstructorEntry {return e})*{return [first].concat(rest)})? _ "}" {return entries ? ["mapConstructor"].concat(entries) : ["mapConstructor"]}
 
 // 171
 MapConstructorEntry

--- a/src/registerXQueryModule.ts
+++ b/src/registerXQueryModule.ts
@@ -25,7 +25,7 @@ export default function registerXQueryModule(
 		debug: options['debug'],
 	});
 
-	annotateAst(parsedModule);
+	annotateAst(parsedModule, { staticContext: undefined, totalNodes: [], totalAnnotated: [] });
 
 	const libraryModule = astHelper.getFirstChild(parsedModule, 'libraryModule');
 	if (!libraryModule) {

--- a/src/registerXQueryModule.ts
+++ b/src/registerXQueryModule.ts
@@ -25,7 +25,7 @@ export default function registerXQueryModule(
 		debug: options['debug'],
 	});
 
-	annotateAst(parsedModule, { staticContext: undefined, totalNodes: 0, totalAnnotated: [] });
+	annotateAst(parsedModule, { staticContext: undefined });
 
 	const libraryModule = astHelper.getFirstChild(parsedModule, 'libraryModule');
 	if (!libraryModule) {

--- a/src/registerXQueryModule.ts
+++ b/src/registerXQueryModule.ts
@@ -25,7 +25,7 @@ export default function registerXQueryModule(
 		debug: options['debug'],
 	});
 
-	annotateAst(parsedModule, { staticContext: undefined, totalNodes: [], totalAnnotated: [] });
+	annotateAst(parsedModule, { staticContext: undefined, totalNodes: 0, totalAnnotated: [] });
 
 	const libraryModule = astHelper.getFirstChild(parsedModule, 'libraryModule');
 	if (!libraryModule) {

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -1,5 +1,5 @@
-import StaticContext from '../expressions/StaticContext';
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
 import { annotateArrayConstructor } from './annotateArrayConstructor';
 import { annotateArrowExpr } from './annotateArrowExpr';
@@ -31,6 +31,7 @@ import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
 
 export type AnnotationContext = {
 	staticContext?: StaticContext;
+	query?: string;
 };
 
 /**
@@ -45,6 +46,25 @@ export default function annotateAst(ast: IAST, context: AnnotationContext) {
 	annotate(ast, context);
 }
 
+export function countQueryBodyAnnotations(
+	ast: IAST,
+	total: number = 0,
+	annotated: number = 0
+): [number, number] {
+	const nodeNames = Object.keys(annotationFunctions);
+
+	for (let i = 1; i < ast.length; i++) {
+		if (Array.isArray(ast[i]))
+			[total, annotated] = countQueryBodyAnnotations(ast[i] as IAST, total, annotated);
+	}
+
+	if (nodeNames.includes(ast[0])) {
+		if (astHelper.getAttribute(ast, 'type')) annotated += 1;
+		total += 1;
+	}
+
+	return [total, annotated];
+}
 /**
  * Recursively traverse the AST in the depth first, pre-order to infer type and annotate AST;
  * Annotates as much type information as possible to the AST nodes.
@@ -63,243 +83,297 @@ function annotate(ast: IAST, context: AnnotationContext): SequenceType | undefin
 
 	const astNodeName = ast[0];
 
-	// Switch on the current node name
-	switch (astNodeName) {
-		// Unary arithmetic operators
-		case 'unaryMinusOp':
-			const minVal = annotate(astHelper.getFirstChild(ast, 'operand')[1] as IAST, context);
-			return annotateUnaryMinus(ast, minVal, context);
-		case 'unaryPlusOp':
-			const plusVal = annotate(astHelper.getFirstChild(ast, 'operand')[1] as IAST, context);
-			return annotateUnaryPlus(ast, plusVal, context);
+	const annotationFunction = annotationFunctions[astNodeName];
+	if (annotationFunction) return annotationFunction(ast, context);
 
-		// Binary arithmetic operators
-		case 'addOp':
-		case 'subtractOp':
-		case 'divOp':
-		case 'idivOp':
-		case 'modOp':
-		case 'multiplyOp': {
-			const left = annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, context);
-			const right = annotate(
-				astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST,
-				context
-			);
-			return annotateBinOp(ast, left, right, astNodeName, context);
-		}
-
-		// And + Or operators
-		case 'andOp':
-		case 'orOp':
-			annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, context);
-			annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, context);
-			return annotateLogicalOperator(ast, context);
-
-		// Sequences
-		case 'sequenceExpr':
-			const children = astHelper.getChildren(ast, '*');
-			children.map((a) => annotate(a, context));
-			return annotateSequenceOperator(ast, children.length, context);
-
-		// Set operations (union, intersect, except)
-		case 'unionOp':
-		case 'intersectOp':
-		case 'exceptOp':
-			const l = annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, context);
-			const r = annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, context);
-			return annotateSetOperator(ast, l, r, context);
-
-		// String concatentation
-		case 'stringConcatenateOp':
-			annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, context);
-			annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, context);
-			return annotateStringConcatenateOperator(ast, context);
-
-		// Range operator
-		case 'rangeSequenceExpr':
-			annotate(astHelper.getFirstChild(ast, 'startExpr')[1] as IAST, context);
-			annotate(astHelper.getFirstChild(ast, 'endExpr')[1] as IAST, context);
-			return annotateRangeSequenceOperator(ast, context);
-
-		// Comparison operators
-		case 'equalOp':
-		case 'notEqualOp':
-		case 'lessThanOrEqualOp':
-		case 'lessThanOp':
-		case 'greaterThanOrEqualOp':
-		case 'greaterThanOp': {
-			annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, context);
-			annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, context);
-			return annotateGeneralCompare(ast, context);
-		}
-		case 'eqOp':
-		case 'neOp':
-		case 'ltOp':
-		case 'leOp':
-		case 'gtOp':
-		case 'geOp': {
-			annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, context);
-			annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, context);
-			return annotateValueCompare(ast, context);
-		}
-		case 'isOp':
-		case 'nodeBeforeOp':
-		case 'nodeAfterOp': {
-			annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, context);
-			annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, context);
-			return annotateNodeCompare(ast, context);
-		}
-
-		// Path Expression
-		case 'pathExpr':
-			const root = astHelper.getFirstChild(ast, 'rootExpr');
-			if (root) annotate(root[1] as IAST, context);
-			astHelper.getChildren(ast, 'stepExpr').map((b) => annotate(b, context));
-			return annotatePathExpr(ast, context);
-
-		// Context Item
-		case 'contextItemExpr':
-			return annotateContextItemExpr(ast);
-		case 'ifThenElseExpr': {
-			const ifClause = annotate(
-				astHelper.getFirstChild(astHelper.getFirstChild(ast, 'ifClause'), '*'),
-				context
-			);
-			const thenClause = annotate(
-				astHelper.getFirstChild(astHelper.getFirstChild(ast, 'thenClause'), '*'),
-				context
-			);
-			const elseClause = annotate(
-				astHelper.getFirstChild(astHelper.getFirstChild(ast, 'elseClause'), '*'),
-				context
-			);
-			return annotateIfThenElseExpr(ast, thenClause, elseClause, context);
-		}
-		case 'instanceOfExpr': {
-			annotate(astHelper.getFirstChild(ast, 'argExpr'), context);
-			annotate(astHelper.getFirstChild(ast, 'sequenceType'), context);
-			return annotateInstanceOfExpr(ast, context);
-		}
-
-		// Constant expressions
-		case 'integerConstantExpr':
-			const integerSequenceType = {
-				type: ValueType.XSINTEGER,
-				mult: SequenceMultiplicity.EXACTLY_ONE,
-			};
-
-			astHelper.insertAttribute(ast, 'type', integerSequenceType);
-			return integerSequenceType;
-		case 'doubleConstantExpr':
-			const doubleSequenceType = {
-				type: ValueType.XSDOUBLE,
-				mult: SequenceMultiplicity.EXACTLY_ONE,
-			};
-
-			astHelper.insertAttribute(ast, 'type', doubleSequenceType);
-			return doubleSequenceType;
-		case 'decimalConstantExpr':
-			const decimalSequenceType = {
-				type: ValueType.XSDECIMAL,
-				mult: SequenceMultiplicity.EXACTLY_ONE,
-			};
-
-			astHelper.insertAttribute(ast, 'type', decimalSequenceType);
-			return decimalSequenceType;
-		case 'stringConstantExpr':
-			const stringSequenceType = {
-				type: ValueType.XSSTRING,
-				mult: SequenceMultiplicity.EXACTLY_ONE,
-			};
-
-			astHelper.insertAttribute(ast, 'type', stringSequenceType);
-			return stringSequenceType;
-
-		// Functions
-		case 'functionCallExpr':
-			const functionArguments = astHelper.getFirstChild(ast, 'arguments');
-			const argumentTypeNodes = astHelper.getChildren(functionArguments, '*');
-			const argumentTypes: SequenceType[] = argumentTypeNodes.map((x) =>
-				annotate(x, context)
-			);
-
-			return annotateFunctionCall(ast, argumentTypes, context);
-		case 'arrowExpr':
-			const functionCallExpr: SequenceType = annotate(
-				astHelper.getFirstChild(ast, 'argExpr')[1] as IAST,
-				context
-			);
-
-			return annotateArrowExpr(ast, functionCallExpr, context);
-		case 'dynamicFunctionInvocationExpr':
-			const functionItem: SequenceType = annotate(
-				astHelper.followPath(ast, ['functionItem', '*']),
-				context
-			);
-			const args: SequenceType = annotate(astHelper.getFirstChild(ast, 'arguments'), context);
-			return annotateDynamicFunctionInvocationExpr(ast, context, functionItem, args);
-		case 'namedFunctionRef':
-			return annotateNamedFunctionRef(ast, context);
-		case 'inlineFunctionExpr':
-			annotate(astHelper.getFirstChild(ast, 'functionBody')[1] as IAST, context);
-			return { type: ValueType.FUNCTION, mult: SequenceMultiplicity.EXACTLY_ONE };
-
-		// Casting
-		case 'castExpr':
-			return annotateCastOperator(ast, context);
-		case 'castableExpr':
-			return annotateCastableOperator(ast, context);
-
-		// Maps
-		case 'simpleMapExpr':
-			astHelper.getChildren(ast, 'pathExpr').map((c) => annotate(c, context));
-			return annotateSimpleMapExpr(ast, context);
-		case 'mapConstructor':
-			astHelper.getChildren(ast, 'mapConstructorEntry').map((keyValuePair) => ({
-				key: annotate(astHelper.followPath(keyValuePair, ['mapKeyExpr', '*']), context),
-				value: annotate(astHelper.followPath(keyValuePair, ['mapValueExpr', '*']), context),
-			}));
-			return annotateMapConstructor(ast, context);
-
-		// Arrays
-		case 'arrayConstructor':
-			astHelper
-				.getChildren(astHelper.getFirstChild(ast, '*'), 'arrayElem')
-				.map((arrayElem) => annotate(arrayElem, context));
-			return annotateArrayConstructor(ast, context);
-
-		// Unary Lookup
-		case 'unaryLookup':
-			const ncName = astHelper.getFirstChild(ast, 'NCName');
-			return annotateUnaryLookup(ast, ncName);
-
-		// TypeSwitch
-		case 'typeSwitchExpr':
-			const arg = annotate(astHelper.getFirstChild(ast, 'argExpr') as IAST, context);
-			const clauses = astHelper
-				.getChildren(ast, 'typeswitchExprCaseClause')
-				.map((a) => annotate(a, context));
-			const defaultCase = annotate(
-				astHelper.getFirstChild(ast, 'typeSwitchExprDefaultClause') as IAST,
-				context
-			);
-			return annotateTypeSwitchOperator(ast);
-
-		case 'quantifiedExpr':
-			astHelper.getChildren(ast, '*').map((a) => annotate(a, context));
-			return annotateQuantifiedExpr(ast, context);
-
-		case 'queryBody':
-			const type = annotate(ast[1] as IAST, context);
-			if (type) {
-				astHelper.insertAttribute(ast, 'type', type);
-			}
-			return type;
-		default:
-			// Current node cannot be annotated, but maybe deeper ones can.
-			for (let i = 1; i < ast.length; i++) {
-				annotate(ast[i] as IAST, context);
-			}
-			return undefined;
+	// Current node cannot be annotated, but maybe deeper ones can.
+	for (let i = 1; i < ast.length; i++) {
+		annotate(ast[i] as IAST, context);
 	}
+
+	return undefined;
 }
+
+/**
+ * The function lambda for annotating binary operators
+ */
+const binopAnnotateCb = (ast: IAST, context: AnnotationContext): SequenceType => {
+	const left = annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, context);
+	const right = annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, context);
+	return annotateBinOp(ast, left, right, ast[0], context);
+};
+
+/**
+ * The function lambda for annotating logical operators
+ */
+const logicOpAnnotateCb = (ast: IAST, context: AnnotationContext): SequenceType => {
+	annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, context);
+	annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, context);
+	return annotateLogicalOperator(ast, context);
+};
+
+/**
+ * The function lambda for annotating set operators
+ */
+const setOpAnnotateCb = (ast: IAST, context: AnnotationContext): SequenceType => {
+	const l = annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, context);
+	const r = annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, context);
+	return annotateSetOperator(ast, l, r, context);
+};
+
+/**
+ * The function lambda for annotating general compare operators
+ */
+const generalComporeAnnotateCb = (ast: IAST, context: AnnotationContext): SequenceType => {
+	annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, context);
+	annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, context);
+	return annotateGeneralCompare(ast, context);
+};
+
+/**
+ * The function lambda for annotating value compare operators
+ */
+const valueCompareAnnotateCb = (ast: IAST, context: AnnotationContext): SequenceType => {
+	annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, context);
+	annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, context);
+	return annotateValueCompare(ast, context);
+};
+
+/**
+ * The function lambda for annotating node compare operators
+ */
+const nodeCompareAnnotateCb = (ast: IAST, context: AnnotationContext): SequenceType => {
+	annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, context);
+	annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, context);
+	return annotateNodeCompare(ast, context);
+};
+
+/**
+ * A lookup table which stores the AST node name and the annotation function lambda. Converting
+ * this from a switch to a map allows us to get a list of all nodes the current system can annotate
+ * using `Object.keys(annotationFunctions)`.
+ */
+const annotationFunctions: {
+	[key: string]: (ast: IAST, context: AnnotationContext) => SequenceType;
+} = {
+	unaryMinusOp: (ast: IAST, context: AnnotationContext): SequenceType => {
+		const minVal = annotate(astHelper.getFirstChild(ast, 'operand')[1] as IAST, context);
+		return annotateUnaryMinus(ast, minVal, context);
+	},
+	unaryPlusOp: (ast: IAST, context: AnnotationContext): SequenceType => {
+		const plusVal = annotate(astHelper.getFirstChild(ast, 'operand')[1] as IAST, context);
+		return annotateUnaryPlus(ast, plusVal, context);
+	},
+
+	// Binary operators
+	addOp: binopAnnotateCb,
+	subtractOp: binopAnnotateCb,
+	divOp: binopAnnotateCb,
+	idivOp: binopAnnotateCb,
+	modOp: binopAnnotateCb,
+	multiplyOp: binopAnnotateCb,
+
+	// And + Or operators
+	andOp: logicOpAnnotateCb,
+	orOp: logicOpAnnotateCb,
+
+	// Sequences
+	sequenceExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		const children = astHelper.getChildren(ast, '*');
+		children.map((a) => annotate(a, context));
+		return annotateSequenceOperator(ast, children.length, context);
+	},
+
+	// Set operations (union, intersect, except)
+	unionOp: setOpAnnotateCb,
+	intersectOp: setOpAnnotateCb,
+	exceptOp: setOpAnnotateCb,
+
+	// String concatentation
+	stringConcatenateOp: (ast: IAST, context: AnnotationContext): SequenceType => {
+		annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, context);
+		annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, context);
+		return annotateStringConcatenateOperator(ast, context);
+	},
+
+	// Range operator
+	rangeSequenceExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		annotate(astHelper.getFirstChild(ast, 'startExpr')[1] as IAST, context);
+		annotate(astHelper.getFirstChild(ast, 'endExpr')[1] as IAST, context);
+		return annotateRangeSequenceOperator(ast, context);
+	},
+
+	// Comparison operators
+	equalOp: generalComporeAnnotateCb,
+	notEqualOp: generalComporeAnnotateCb,
+	lessThanOrEqualOp: generalComporeAnnotateCb,
+	lessThanOp: generalComporeAnnotateCb,
+	greaterThanOrEqualOp: generalComporeAnnotateCb,
+	greaterThanOp: generalComporeAnnotateCb,
+	eqOp: valueCompareAnnotateCb,
+	neOp: valueCompareAnnotateCb,
+	ltOp: valueCompareAnnotateCb,
+	leOp: valueCompareAnnotateCb,
+	gtOp: valueCompareAnnotateCb,
+	geOp: valueCompareAnnotateCb,
+	isOp: nodeCompareAnnotateCb,
+	nodeBeforeOp: nodeCompareAnnotateCb,
+	nodeAfterOp: nodeCompareAnnotateCb,
+
+	// Path Expression
+	pathExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		const root = astHelper.getFirstChild(ast, 'rootExpr');
+		if (root) annotate(root[1] as IAST, context);
+		astHelper.getChildren(ast, 'stepExpr').map((b) => annotate(b, context));
+		return annotatePathExpr(ast, context);
+	},
+
+	// Context Item
+	contextItemExpr: (ast, _context) => {
+		return annotateContextItemExpr(ast);
+	},
+	ifThenElseExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		const ifClause = annotate(
+			astHelper.getFirstChild(astHelper.getFirstChild(ast, 'ifClause'), '*'),
+			context
+		);
+		const thenClause = annotate(
+			astHelper.getFirstChild(astHelper.getFirstChild(ast, 'thenClause'), '*'),
+			context
+		);
+		const elseClause = annotate(
+			astHelper.getFirstChild(astHelper.getFirstChild(ast, 'elseClause'), '*'),
+			context
+		);
+		return annotateIfThenElseExpr(ast, thenClause, elseClause, context);
+	},
+	instanceOfExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		annotate(astHelper.getFirstChild(ast, 'argExpr'), context);
+		annotate(astHelper.getFirstChild(ast, 'sequenceType'), context);
+		return annotateInstanceOfExpr(ast, context);
+	},
+
+	// Constant expressions
+	integerConstantExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		const integerSequenceType = {
+			type: ValueType.XSINTEGER,
+			mult: SequenceMultiplicity.EXACTLY_ONE,
+		};
+
+		astHelper.insertAttribute(ast, 'type', integerSequenceType);
+		return integerSequenceType;
+	},
+	doubleConstantExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		const doubleSequenceType = {
+			type: ValueType.XSDOUBLE,
+			mult: SequenceMultiplicity.EXACTLY_ONE,
+		};
+
+		astHelper.insertAttribute(ast, 'type', doubleSequenceType);
+		return doubleSequenceType;
+	},
+	decimalConstantExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		const decimalSequenceType = {
+			type: ValueType.XSDECIMAL,
+			mult: SequenceMultiplicity.EXACTLY_ONE,
+		};
+
+		astHelper.insertAttribute(ast, 'type', decimalSequenceType);
+		return decimalSequenceType;
+	},
+	stringConstantExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		const stringSequenceType = {
+			type: ValueType.XSSTRING,
+			mult: SequenceMultiplicity.EXACTLY_ONE,
+		};
+
+		astHelper.insertAttribute(ast, 'type', stringSequenceType);
+		return stringSequenceType;
+	},
+
+	// Functions
+	functionCallExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		const functionArguments = astHelper.getFirstChild(ast, 'arguments');
+		const argumentTypeNodes = astHelper.getChildren(functionArguments, '*');
+		const argumentTypes: SequenceType[] = argumentTypeNodes.map((x) => annotate(x, context));
+
+		return annotateFunctionCall(ast, argumentTypes, context);
+	},
+	arrowExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		const functionCallExpr: SequenceType = annotate(
+			astHelper.getFirstChild(ast, 'argExpr')[1] as IAST,
+			context
+		);
+
+		return annotateArrowExpr(ast, functionCallExpr, context);
+	},
+	dynamicFunctionInvocationExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		const functionItem: SequenceType = annotate(
+			astHelper.followPath(ast, ['functionItem', '*']),
+			context
+		);
+		const args: SequenceType = annotate(astHelper.getFirstChild(ast, 'arguments'), context);
+		return annotateDynamicFunctionInvocationExpr(ast, context, functionItem, args);
+	},
+	namedFunctionRef: (ast: IAST, context: AnnotationContext): SequenceType => {
+		return annotateNamedFunctionRef(ast, context);
+	},
+	inlineFunctionExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		annotate(astHelper.getFirstChild(ast, 'functionBody')[1] as IAST, context);
+		return { type: ValueType.FUNCTION, mult: SequenceMultiplicity.EXACTLY_ONE };
+	},
+	// Casting
+	castExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		return annotateCastOperator(ast, context);
+	},
+	castableExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		return annotateCastableOperator(ast, context);
+	},
+	// Maps
+	simpleMapExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		astHelper.getChildren(ast, 'pathExpr').map((c) => annotate(c, context));
+		return annotateSimpleMapExpr(ast, context);
+	},
+	mapConstructor: (ast: IAST, context: AnnotationContext): SequenceType => {
+		astHelper.getChildren(ast, 'mapConstructorEntry').map((keyValuePair) => ({
+			key: annotate(astHelper.followPath(keyValuePair, ['mapKeyExpr', '*']), context),
+			value: annotate(astHelper.followPath(keyValuePair, ['mapValueExpr', '*']), context),
+		}));
+		return annotateMapConstructor(ast, context);
+	},
+	// Arrays
+	arrayConstructor: (ast: IAST, context: AnnotationContext): SequenceType => {
+		astHelper
+			.getChildren(astHelper.getFirstChild(ast, '*'), 'arrayElem')
+			.map((arrayElem) => annotate(arrayElem, context));
+		return annotateArrayConstructor(ast, context);
+	},
+	// Unary Lookup
+	unaryLookup: (ast: IAST, context: AnnotationContext): SequenceType => {
+		const ncName = astHelper.getFirstChild(ast, 'NCName');
+		return annotateUnaryLookup(ast, ncName);
+	},
+	// TypeSwitch
+	typeSwitchExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		const arg = annotate(astHelper.getFirstChild(ast, 'argExpr') as IAST, context);
+		const clauses = astHelper
+			.getChildren(ast, 'typeswitchExprCaseClause')
+			.map((a) => annotate(a, context));
+		const defaultCase = annotate(
+			astHelper.getFirstChild(ast, 'typeSwitchExprDefaultClause') as IAST,
+			context
+		);
+		return annotateTypeSwitchOperator(ast);
+	},
+	quantifiedExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
+		astHelper.getChildren(ast, '*').map((a) => annotate(a, context));
+		return annotateQuantifiedExpr(ast, context);
+	},
+	queryBody: (ast: IAST, context: AnnotationContext): SequenceType => {
+		const type = annotate(ast[1] as IAST, context);
+		if (type) {
+			astHelper.insertAttribute(ast, 'type', type);
+		}
+		return type;
+	},
+};

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -57,13 +57,15 @@ export default function annotateAst(ast: IAST, context: AnnotationContext) {
  * @throws errors when attempts to annotate fail.
  * @returns The type of the AST node or `undefined` when the type cannot be annotated.
  */
-export function annotate(ast: IAST, context: AnnotationContext): SequenceType | undefined {
+function annotate(ast: IAST, context: AnnotationContext): SequenceType | undefined {
 	// Check if we actually have an AST
 	if (!ast) {
 		return undefined;
 	}
 
 	const astNodeName = ast[0];
+
+	// context.
 
 	// Switch on the current node name
 	switch (astNodeName) {

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -31,8 +31,6 @@ import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
 
 export type AnnotationContext = {
 	staticContext?: StaticContext;
-	totalNodes: number;
-	totalAnnotated: number[];
 };
 
 /**
@@ -43,29 +41,8 @@ export type AnnotationContext = {
  * @param ast The AST to annotate
  * @param context The static context used for function lookups
  */
-export default function annotateAst(ast: IAST, context: AnnotationContext): number {
-	for (let i = 0; i < 10; i++) {
-		context.totalAnnotated.push(0);
-		context.totalNodes = 0;
-
-		annotate(ast, context);
-
-		if (
-			(context.totalAnnotated.length > 1 &&
-				context.totalAnnotated[context.totalAnnotated.length - 2] ===
-					context.totalAnnotated[context.totalAnnotated.length - 1]) ||
-			context.totalAnnotated[context.totalAnnotated.length - 1] === context.totalNodes
-		) {
-			break;
-		}
-	}
-
-	// console.error(
-	// 	context.totalAnnotated.length +
-	// 		' passes ' +
-	// 		context.totalAnnotated[context.totalAnnotated.length - 1] / context.totalNodes
-	// );
-	return context.totalAnnotated[context.totalAnnotated.length - 1] / context.totalNodes;
+export default function annotateAst(ast: IAST, context: AnnotationContext) {
+	annotate(ast, context);
 }
 
 /**
@@ -85,8 +62,6 @@ function annotate(ast: IAST, context: AnnotationContext): SequenceType | undefin
 	}
 
 	const astNodeName = ast[0];
-
-	context.totalNodes++;
 
 	// Switch on the current node name
 	switch (astNodeName) {
@@ -213,7 +188,6 @@ function annotate(ast: IAST, context: AnnotationContext): SequenceType | undefin
 				mult: SequenceMultiplicity.EXACTLY_ONE,
 			};
 
-			context.totalAnnotated[context.totalAnnotated.length - 1]++;
 			astHelper.insertAttribute(ast, 'type', integerSequenceType);
 			return integerSequenceType;
 		case 'doubleConstantExpr':
@@ -222,7 +196,6 @@ function annotate(ast: IAST, context: AnnotationContext): SequenceType | undefin
 				mult: SequenceMultiplicity.EXACTLY_ONE,
 			};
 
-			context.totalAnnotated[context.totalAnnotated.length - 1]++;
 			astHelper.insertAttribute(ast, 'type', doubleSequenceType);
 			return doubleSequenceType;
 		case 'decimalConstantExpr':
@@ -231,7 +204,6 @@ function annotate(ast: IAST, context: AnnotationContext): SequenceType | undefin
 				mult: SequenceMultiplicity.EXACTLY_ONE,
 			};
 
-			context.totalAnnotated[context.totalAnnotated.length - 1]++;
 			astHelper.insertAttribute(ast, 'type', decimalSequenceType);
 			return decimalSequenceType;
 		case 'stringConstantExpr':
@@ -240,7 +212,6 @@ function annotate(ast: IAST, context: AnnotationContext): SequenceType | undefin
 				mult: SequenceMultiplicity.EXACTLY_ONE,
 			};
 
-			context.totalAnnotated[context.totalAnnotated.length - 1]++;
 			astHelper.insertAttribute(ast, 'type', stringSequenceType);
 			return stringSequenceType;
 
@@ -321,7 +292,6 @@ function annotate(ast: IAST, context: AnnotationContext): SequenceType | undefin
 		case 'queryBody':
 			const type = annotate(ast[1] as IAST, context);
 			if (type) {
-				context.totalAnnotated[context.totalAnnotated.length - 1]++;
 				astHelper.insertAttribute(ast, 'type', type);
 			}
 			return type;
@@ -330,7 +300,6 @@ function annotate(ast: IAST, context: AnnotationContext): SequenceType | undefin
 			for (let i = 1; i < ast.length; i++) {
 				annotate(ast[i] as IAST, context);
 			}
-			context.totalNodes--;
 			return undefined;
 	}
 }

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -31,7 +31,7 @@ import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
 
 export type AnnotationContext = {
 	staticContext?: StaticContext;
-	totalNodes: number[];
+	totalNodes: number;
 	totalAnnotated: number[];
 };
 
@@ -44,6 +44,9 @@ export type AnnotationContext = {
  * @param context The static context used for function lookups
  */
 export default function annotateAst(ast: IAST, context: AnnotationContext) {
+	context.totalAnnotated.push(0);
+	context.totalNodes = 0;
+
 	annotate(ast, context);
 }
 
@@ -65,7 +68,7 @@ function annotate(ast: IAST, context: AnnotationContext): SequenceType | undefin
 
 	const astNodeName = ast[0];
 
-	// context.
+	context.totalNodes++;
 
 	// Switch on the current node name
 	switch (astNodeName) {

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -245,10 +245,11 @@ function annotate(ast: IAST, context: AnnotationContext): SequenceType | undefin
 
 		// Functions
 		case 'functionCallExpr':
-			const argumentTypes: SequenceType[] = (astHelper.getChildren(
-				ast,
-				'*'
-			)[1] as IAST[]).map((x) => annotate(x, context));
+			const functionArguments = astHelper.getFirstChild(ast, 'arguments');
+			const argumentTypeNodes = astHelper.getChildren(functionArguments, '*');
+			const argumentTypes: SequenceType[] = argumentTypeNodes.map((x) =>
+				annotate(x, context)
+			);
 
 			return annotateFunctionCall(ast, argumentTypes, context);
 		case 'arrowExpr':

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -321,6 +321,7 @@ function annotate(ast: IAST, context: AnnotationContext): SequenceType | undefin
 		case 'queryBody':
 			const type = annotate(ast[1] as IAST, context);
 			if (type) {
+				context.totalAnnotated[context.totalAnnotated.length - 1]++;
 				astHelper.insertAttribute(ast, 'type', type);
 			}
 			return type;

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -47,9 +47,22 @@ export default function annotateAst(ast: IAST, context: AnnotationContext) {
 	context.totalAnnotated.push(0);
 	context.totalNodes = 0;
 
-	annotate(ast, context);
+	for (let i = 0; i < 10; i++) {
+		annotate(ast, context);
 
-	console.error(context.totalAnnotated[context.totalAnnotated.length - 1] / context.totalNodes);
+		if (
+			context.totalAnnotated[context.totalAnnotated.length - 2] ===
+			context.totalAnnotated[context.totalAnnotated.length - 1]
+		) {
+			break;
+		}
+	}
+
+	console.error(
+		context.totalAnnotated.length +
+			' passes ' +
+			context.totalAnnotated[context.totalAnnotated.length - 1] / context.totalNodes
+	);
 }
 
 /**

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -317,6 +317,12 @@ function annotate(ast: IAST, context: AnnotationContext): SequenceType | undefin
 			astHelper.getChildren(ast, '*').map((a) => annotate(a, context));
 			return annotateQuantifiedExpr(ast, context);
 
+		case 'queryBody':
+			const type = annotate(ast[1] as IAST, context);
+			if (type) {
+				astHelper.insertAttribute(ast, 'type', type);
+			}
+			return type;
 		default:
 			// Current node cannot be annotated, but maybe deeper ones can.
 			for (let i = 1; i < ast.length; i++) {

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -30,8 +30,8 @@ import { annotateUnaryLookup } from './annotateUnaryLookup';
 import { annotateUnaryMinus, annotateUnaryPlus } from './annotateUnaryOperator';
 
 export type AnnotationContext = {
-	staticContext?: StaticContext;
 	query?: string;
+	staticContext?: StaticContext;
 };
 
 /**

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -167,6 +167,7 @@ function annotate(ast: IAST, context: AnnotationContext): SequenceType | undefin
 			annotate(astHelper.getFirstChild(ast, 'secondOperand')[1] as IAST, context);
 			return annotateValueCompare(ast, context);
 		}
+		case 'isOp':
 		case 'nodeBeforeOp':
 		case 'nodeAfterOp': {
 			annotate(astHelper.getFirstChild(ast, 'firstOperand')[1] as IAST, context);

--- a/src/typeInference/annotateArrayConstructor.ts
+++ b/src/typeInference/annotateArrayConstructor.ts
@@ -1,5 +1,6 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Inserting the array type of multiplicity exactly one to the ast;
@@ -8,12 +9,13 @@ import astHelper, { IAST } from '../parsing/astHelper';
  * @param ast the AST to be annotated.
  * @returns the inferred SequenceType
  */
-export function annotateArrayConstructor(ast: IAST): SequenceType {
+export function annotateArrayConstructor(ast: IAST, context: AnnotationContext): SequenceType {
 	const seqType = {
 		type: ValueType.ARRAY,
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;

--- a/src/typeInference/annotateArrayConstructor.ts
+++ b/src/typeInference/annotateArrayConstructor.ts
@@ -15,7 +15,6 @@ export function annotateArrayConstructor(ast: IAST, context: AnnotationContext):
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;

--- a/src/typeInference/annotateArrowExpr.ts
+++ b/src/typeInference/annotateArrowExpr.ts
@@ -55,6 +55,7 @@ export function annotateArrowExpr(ast: IAST, context: AnnotationContext): Sequen
 
 	if (!functionProps) return undefined;
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', functionProps.returnType);
 	return functionProps.returnType;
 }

--- a/src/typeInference/annotateArrowExpr.ts
+++ b/src/typeInference/annotateArrowExpr.ts
@@ -60,7 +60,6 @@ export function annotateArrowExpr(
 
 	if (!functionProps) return undefined;
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', functionProps.returnType);
 	return functionProps.returnType;
 }

--- a/src/typeInference/annotateArrowExpr.ts
+++ b/src/typeInference/annotateArrowExpr.ts
@@ -11,7 +11,11 @@ import { AnnotationContext } from './annotateAST';
  * @param staticContext from witch the function info is extracted.
  * @returns the inferred type or `undefined` when function properties cannot be inferred.
  */
-export function annotateArrowExpr(ast: IAST, context: AnnotationContext): SequenceType | undefined {
+export function annotateArrowExpr(
+	ast: IAST,
+	functionCallExpr: SequenceType,
+	context: AnnotationContext
+): SequenceType | undefined {
 	// We need the context to lookup the function information
 	if (!context.staticContext) return undefined;
 
@@ -50,7 +54,8 @@ export function annotateArrowExpr(ast: IAST, context: AnnotationContext): Sequen
 	const functionProps = context.staticContext.lookupFunction(
 		resolvedName.namespaceURI,
 		resolvedName.localName,
-		functionArguments.length
+		// Since this is an arrowExpr, we add one for the implicit argument
+		functionArguments.length + 1
 	);
 
 	if (!functionProps) return undefined;

--- a/src/typeInference/annotateArrowExpr.ts
+++ b/src/typeInference/annotateArrowExpr.ts
@@ -1,6 +1,7 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
 import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Annotate the arrowExpr by extracting the function info from the static context
@@ -10,12 +11,9 @@ import astHelper, { IAST } from '../parsing/astHelper';
  * @param staticContext from witch the function info is extracted.
  * @returns the inferred type or `undefined` when function properties cannot be inferred.
  */
-export function annotateArrowExpr(
-	ast: IAST,
-	staticContext: StaticContext
-): SequenceType | undefined {
+export function annotateArrowExpr(ast: IAST, context: AnnotationContext): SequenceType | undefined {
 	// We need the context to lookup the function information
-	if (!staticContext) return undefined;
+	if (!context.staticContext) return undefined;
 
 	const func = astHelper.getFirstChild(ast, 'EQName');
 
@@ -38,7 +36,7 @@ export function annotateArrowExpr(
 	const functionArguments = astHelper.getChildren(astHelper.getFirstChild(ast, 'arguments'), '*');
 
 	// Lookup the namespace URI
-	const resolvedName = staticContext.resolveFunctionName(
+	const resolvedName = context.staticContext.resolveFunctionName(
 		{
 			localName: functionName,
 			prefix: functionPrefix['prefix'] as string,
@@ -49,7 +47,7 @@ export function annotateArrowExpr(
 	if (!resolvedName) return undefined;
 
 	// Lookup the function properties (return type)
-	const functionProps = staticContext.lookupFunction(
+	const functionProps = context.staticContext.lookupFunction(
 		resolvedName.namespaceURI,
 		resolvedName.localName,
 		functionArguments.length

--- a/src/typeInference/annotateBinaryOperator.ts
+++ b/src/typeInference/annotateBinaryOperator.ts
@@ -38,7 +38,7 @@ export function annotateBinOp(
 
 	if (funcData !== undefined) {
 		const type = { type: funcData, mult: left.mult };
-		context.totalAnnotated[context.totalAnnotated.length - 1]++;
+
 		astHelper.insertAttribute(ast, 'type', type);
 		return type;
 	}

--- a/src/typeInference/annotateBinaryOperator.ts
+++ b/src/typeInference/annotateBinaryOperator.ts
@@ -4,6 +4,7 @@ import {
 	getBinaryPrefabOperator,
 } from '../expressions/operators/arithmetic/BinaryOperator';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Annotate the binary operators on the numeric and date types
@@ -21,7 +22,8 @@ export function annotateBinOp(
 	ast: IAST,
 	left: SequenceType | undefined,
 	right: SequenceType | undefined,
-	operator: string
+	operator: string,
+	context: AnnotationContext
 ): SequenceType | undefined {
 	// If we don't have the left and right type, we cannot infer the current type
 	if (!left || !right) {
@@ -35,6 +37,7 @@ export function annotateBinOp(
 
 	if (funcData !== undefined) {
 		const type = { type: funcData, mult: left.mult };
+		context.totalAnnotated[context.totalAnnotated.length - 1]++;
 		astHelper.insertAttribute(ast, 'type', type);
 		return type;
 	}

--- a/src/typeInference/annotateBinaryOperator.ts
+++ b/src/typeInference/annotateBinaryOperator.ts
@@ -32,6 +32,7 @@ export function annotateBinOp(
 
 	// TODO: Fix this hack (pathExpr returns a node in 1 case, which cannot be added to an integer)
 	if (left.type === ValueType.NODE || right.type === ValueType.NODE) return undefined;
+	if (left.type === ValueType.ITEM || right.type === ValueType.ITEM) return undefined;
 
 	const funcData = generateBinaryOperatorType(operator, left.type, right.type);
 

--- a/src/typeInference/annotateCastOperators.ts
+++ b/src/typeInference/annotateCastOperators.ts
@@ -18,7 +18,7 @@ export function annotateCastOperator(ast: IAST, context: AnnotationContext): Seq
 	const targetTypeString = getTargetTypeFromAST(ast);
 	const targetValueType = stringToValueType(targetTypeString);
 	const sequenceType = { type: targetValueType, mult: SequenceMultiplicity.EXACTLY_ONE };
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
+
 	astHelper.insertAttribute(ast, 'type', sequenceType);
 	return sequenceType;
 }
@@ -31,7 +31,7 @@ export function annotateCastOperator(ast: IAST, context: AnnotationContext): Seq
  */
 export function annotateCastableOperator(ast: IAST, context: AnnotationContext): SequenceType {
 	const sequenceType = { type: ValueType.XSBOOLEAN, mult: SequenceMultiplicity.EXACTLY_ONE };
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
+
 	astHelper.insertAttribute(ast, 'type', sequenceType);
 	return sequenceType;
 }

--- a/src/typeInference/annotateCastOperators.ts
+++ b/src/typeInference/annotateCastOperators.ts
@@ -5,6 +5,7 @@ import {
 	ValueType,
 } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Read the target type of the cast operator from the AST and
@@ -13,10 +14,11 @@ import astHelper, { IAST } from '../parsing/astHelper';
  * @param ast the AST to be annotated
  * @returns the inferred type
  */
-export function annotateCastOperator(ast: IAST): SequenceType {
+export function annotateCastOperator(ast: IAST, context: AnnotationContext): SequenceType {
 	const targetTypeString = getTargetTypeFromAST(ast);
 	const targetValueType = stringToValueType(targetTypeString);
 	const sequenceType = { type: targetValueType, mult: SequenceMultiplicity.EXACTLY_ONE };
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', sequenceType);
 	return sequenceType;
 }
@@ -27,8 +29,9 @@ export function annotateCastOperator(ast: IAST): SequenceType {
  * @param ast the AST to be annotated
  * @returns `SequenceType` of type boolean and multiplicity of `Exactly_ONE`
  */
-export function annotateCastableOperator(ast: IAST): SequenceType {
+export function annotateCastableOperator(ast: IAST, context: AnnotationContext): SequenceType {
 	const sequenceType = { type: ValueType.XSBOOLEAN, mult: SequenceMultiplicity.EXACTLY_ONE };
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', sequenceType);
 	return sequenceType;
 }

--- a/src/typeInference/annotateCompareOperator.ts
+++ b/src/typeInference/annotateCompareOperator.ts
@@ -16,7 +16,6 @@ export function annotateGeneralCompare(ast: IAST, context: AnnotationContext): S
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;
@@ -36,7 +35,6 @@ export function annotateValueCompare(ast: IAST, context: AnnotationContext): Seq
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;
@@ -56,7 +54,6 @@ export function annotateNodeCompare(ast: IAST, context: AnnotationContext): Sequ
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;

--- a/src/typeInference/annotateCompareOperator.ts
+++ b/src/typeInference/annotateCompareOperator.ts
@@ -1,5 +1,6 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Annotates the AST for the general comparison operator:
@@ -9,12 +10,13 @@ import astHelper, { IAST } from '../parsing/astHelper';
  * @returns At the moment this always returns a boolean, because regardless.
  * of the input, that's what a comparison will return.
  */
-export function annotateGeneralCompare(ast: IAST): SequenceType {
+export function annotateGeneralCompare(ast: IAST, context: AnnotationContext): SequenceType {
 	const seqType = {
 		type: ValueType.XSBOOLEAN,
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;
@@ -28,12 +30,13 @@ export function annotateGeneralCompare(ast: IAST): SequenceType {
  * @returns At the moment this always returns a boolean, because regardless.
  * of the input, that's what a comparison will return.
  */
-export function annotateValueCompare(ast: IAST): SequenceType {
+export function annotateValueCompare(ast: IAST, context: AnnotationContext): SequenceType {
 	const seqType = {
 		type: ValueType.XSBOOLEAN,
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;
@@ -47,12 +50,13 @@ export function annotateValueCompare(ast: IAST): SequenceType {
  * @returns At the moment this always returns a boolean, because regardless.
  * of the input, that's what a comparison will return.
  */
-export function annotateNodeCompare(ast: IAST): SequenceType {
+export function annotateNodeCompare(ast: IAST, context: AnnotationContext): SequenceType {
 	const seqType = {
 		type: ValueType.XSBOOLEAN,
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;

--- a/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
+++ b/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
@@ -1,6 +1,7 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
 import StaticContext from '../expressions/StaticContext';
 import { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * At this moment there is no way to infer the return type of this function as
@@ -14,7 +15,7 @@ import { IAST } from '../parsing/astHelper';
  */
 export function annotateDynamicFunctionInvocationExpr(
 	ast: IAST,
-	staticContext: StaticContext,
+	context: AnnotationContext,
 	functionItem: SequenceType,
 	args: SequenceType
 ): SequenceType {

--- a/src/typeInference/annotateFunctionCall.ts
+++ b/src/typeInference/annotateFunctionCall.ts
@@ -51,7 +51,6 @@ export function annotateFunctionCall(
 
 	if (!functionProps) return undefined;
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', functionProps.returnType);
 	return functionProps.returnType;
 }

--- a/src/typeInference/annotateFunctionCall.ts
+++ b/src/typeInference/annotateFunctionCall.ts
@@ -1,5 +1,4 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
-import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
 import { AnnotationContext } from './annotateAST';
 
@@ -34,7 +33,7 @@ export function annotateFunctionCall(
 	// Lookup the namespace URI
 	const resolvedName = context.staticContext.resolveFunctionName(
 		{
-			localName: functionName as string,
+			localName: functionName,
 			prefix: functionPrefix['prefix'] as string,
 		},
 		functionArguments.length

--- a/src/typeInference/annotateFunctionCall.ts
+++ b/src/typeInference/annotateFunctionCall.ts
@@ -42,6 +42,7 @@ export function annotateFunctionCall(
 
 	if (!functionProps) return undefined;
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', functionProps.returnType);
 	return functionProps.returnType;
 }

--- a/src/typeInference/annotateFunctionCall.ts
+++ b/src/typeInference/annotateFunctionCall.ts
@@ -13,13 +13,22 @@ import { AnnotationContext } from './annotateAST';
  */
 export function annotateFunctionCall(
 	ast: IAST,
+	argumentTypes: SequenceType[],
 	context: AnnotationContext
 ): SequenceType | undefined {
 	// We need the context to lookup the function information
 	if (!context.staticContext) return undefined;
 
-	const functionName = astHelper.getFirstChild(ast, 'functionName')[2];
-	const functionPrefix = astHelper.getFirstChild(ast, 'functionName')[1];
+	const func = astHelper.getFirstChild(ast, 'functionName');
+	let functionName: string;
+	let functionPrefix: string;
+	if (func.length === 3) {
+		functionName = func[2] as string;
+		functionPrefix = func[1] as string;
+	} else {
+		functionName = func[1] as string;
+		functionPrefix = '';
+	}
 	const functionArguments = astHelper.getChildren(astHelper.getFirstChild(ast, 'arguments'), '*');
 
 	// Lookup the namespace URI

--- a/src/typeInference/annotateFunctionCall.ts
+++ b/src/typeInference/annotateFunctionCall.ts
@@ -1,6 +1,7 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
 import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Annotate the function calls by extracting the function info from the static context
@@ -12,17 +13,17 @@ import astHelper, { IAST } from '../parsing/astHelper';
  */
 export function annotateFunctionCall(
 	ast: IAST,
-	staticContext: StaticContext
+	context: AnnotationContext
 ): SequenceType | undefined {
 	// We need the context to lookup the function information
-	if (!staticContext) return undefined;
+	if (!context.staticContext) return undefined;
 
 	const functionName = astHelper.getFirstChild(ast, 'functionName')[2];
 	const functionPrefix = astHelper.getFirstChild(ast, 'functionName')[1];
 	const functionArguments = astHelper.getChildren(astHelper.getFirstChild(ast, 'arguments'), '*');
 
 	// Lookup the namespace URI
-	const resolvedName = staticContext.resolveFunctionName(
+	const resolvedName = context.staticContext.resolveFunctionName(
 		{
 			localName: functionName as string,
 			prefix: functionPrefix['prefix'] as string,
@@ -33,7 +34,7 @@ export function annotateFunctionCall(
 	if (!resolvedName) return undefined;
 
 	// Lookup the function properties (return type)
-	const functionProps = staticContext.lookupFunction(
+	const functionProps = context.staticContext.lookupFunction(
 		resolvedName.namespaceURI,
 		resolvedName.localName,
 		functionArguments.length

--- a/src/typeInference/annotateIfThenElseExpr.ts
+++ b/src/typeInference/annotateIfThenElseExpr.ts
@@ -1,5 +1,6 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Checks the type and multiplicity of else clause and then clause
@@ -13,12 +14,14 @@ import astHelper, { IAST } from '../parsing/astHelper';
 export function annotateIfThenElseExpr(
 	ast: IAST,
 	elseClause: SequenceType,
-	thenClause: SequenceType
+	thenClause: SequenceType,
+	context: AnnotationContext
 ): SequenceType {
 	if (!elseClause || !thenClause) {
 		return undefined;
 	}
 	if (elseClause.type === thenClause.type && elseClause.mult === thenClause.mult) {
+		context.totalAnnotated[context.totalAnnotated.length - 1]++;
 		astHelper.insertAttribute(ast, 'type', elseClause);
 		return elseClause;
 	}

--- a/src/typeInference/annotateIfThenElseExpr.ts
+++ b/src/typeInference/annotateIfThenElseExpr.ts
@@ -21,7 +21,6 @@ export function annotateIfThenElseExpr(
 		return undefined;
 	}
 	if (elseClause.type === thenClause.type && elseClause.mult === thenClause.mult) {
-		context.totalAnnotated[context.totalAnnotated.length - 1]++;
 		astHelper.insertAttribute(ast, 'type', elseClause);
 		return elseClause;
 	}

--- a/src/typeInference/annotateInstanceOfExpr.ts
+++ b/src/typeInference/annotateInstanceOfExpr.ts
@@ -15,7 +15,6 @@ export function annotateInstanceOfExpr(ast: IAST, context: AnnotationContext): S
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;

--- a/src/typeInference/annotateInstanceOfExpr.ts
+++ b/src/typeInference/annotateInstanceOfExpr.ts
@@ -1,5 +1,6 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Insert type boolean multiplicity exactly one the type to the ast
@@ -8,12 +9,13 @@ import astHelper, { IAST } from '../parsing/astHelper';
  * @param ast the AST to be annotated.
  * @returns the type of the context item.
  */
-export function annotateInstanceOfExpr(ast: IAST): SequenceType {
+export function annotateInstanceOfExpr(ast: IAST, context: AnnotationContext): SequenceType {
 	const seqType = {
 		type: ValueType.XSBOOLEAN,
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;

--- a/src/typeInference/annotateLogicalOperator.ts
+++ b/src/typeInference/annotateLogicalOperator.ts
@@ -28,7 +28,6 @@ function annotateOrOperator(ast: IAST, context: AnnotationContext): SequenceType
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;
@@ -46,7 +45,6 @@ function annotateAndOperator(ast: IAST, context: AnnotationContext): SequenceTyp
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;

--- a/src/typeInference/annotateLogicalOperator.ts
+++ b/src/typeInference/annotateLogicalOperator.ts
@@ -1,17 +1,18 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Switch cases that take care of the operators under the logical operator category.
  *
  * @param ast The AST to annotate.
  */
-export function annotateLogicalOperator(ast: IAST): SequenceType {
+export function annotateLogicalOperator(ast: IAST, context: AnnotationContext): SequenceType {
 	switch (ast[0]) {
 		case 'andOp':
-			return annotateAndOperator(ast);
+			return annotateAndOperator(ast, context);
 		case 'orOp':
-			return annotateOrOperator(ast);
+			return annotateOrOperator(ast, context);
 	}
 }
 
@@ -21,12 +22,13 @@ export function annotateLogicalOperator(ast: IAST): SequenceType {
  * @param ast the AST to be annotated.
  * @returns `SequenceType` of type boolean and multiplicity of `Exactly_ONE`.
  */
-function annotateOrOperator(ast: IAST): SequenceType {
+function annotateOrOperator(ast: IAST, context: AnnotationContext): SequenceType {
 	const seqType = {
 		type: ValueType.XSBOOLEAN,
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;
@@ -38,12 +40,13 @@ function annotateOrOperator(ast: IAST): SequenceType {
  * @param ast the AST to be annotated.
  * @returns `SequenceType` of type boolean and multiplicity of `Exactly_ONE`.
  */
-function annotateAndOperator(ast: IAST): SequenceType {
+function annotateAndOperator(ast: IAST, context: AnnotationContext): SequenceType {
 	const seqType = {
 		type: ValueType.XSBOOLEAN,
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;

--- a/src/typeInference/annotateMapConstructor.ts
+++ b/src/typeInference/annotateMapConstructor.ts
@@ -15,7 +15,6 @@ export function annotateMapConstructor(ast: IAST, context: AnnotationContext): S
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 	return seqType;
 }

--- a/src/typeInference/annotateMapConstructor.ts
+++ b/src/typeInference/annotateMapConstructor.ts
@@ -1,5 +1,6 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Inserting the map type of multiplicity exactly one to the ast;
@@ -8,12 +9,13 @@ import astHelper, { IAST } from '../parsing/astHelper';
  * @param ast the AST to be annotated.
  * @returns the inferred SequenceType
  */
-export function annotateMapConstructor(ast: IAST): SequenceType {
+export function annotateMapConstructor(ast: IAST, context: AnnotationContext): SequenceType {
 	const seqType = {
 		type: ValueType.MAP,
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 	return seqType;
 }

--- a/src/typeInference/annotateNamedFunctionRef.ts
+++ b/src/typeInference/annotateNamedFunctionRef.ts
@@ -1,6 +1,7 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
 import StaticContext from '../expressions/StaticContext';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Annotate named function references by extracting the function info from the static context
@@ -12,10 +13,10 @@ import astHelper, { IAST } from '../parsing/astHelper';
  */
 export function annotateNamedFunctionRef(
 	ast: IAST,
-	staticContext: StaticContext
+	context: AnnotationContext
 ): SequenceType | undefined {
 	// Can't find info about the function without the context.
-	if (!staticContext) return undefined;
+	if (!context.staticContext) return undefined;
 
 	// Get qualified function name
 	const functionQName = astHelper.getQName(astHelper.getFirstChild(ast, 'functionName'));
@@ -29,7 +30,10 @@ export function annotateNamedFunctionRef(
 
 	// If there is no namespace URI, resolve the function name
 	if (!namespaceURI) {
-		const functionName = staticContext.resolveFunctionName({ localName, prefix }, arity);
+		const functionName = context.staticContext.resolveFunctionName(
+			{ localName, prefix },
+			arity
+		);
 
 		if (!functionName) {
 			return undefined;
@@ -40,7 +44,8 @@ export function annotateNamedFunctionRef(
 	}
 
 	// With all components there, look up the function properties
-	const functionProperties = staticContext.lookupFunction(namespaceURI, localName, arity) || null;
+	const functionProperties =
+		context.staticContext.lookupFunction(namespaceURI, localName, arity) || null;
 
 	// If there are no function properties, there is no type inference
 	if (!functionProperties) return undefined;

--- a/src/typeInference/annotateNamedFunctionRef.ts
+++ b/src/typeInference/annotateNamedFunctionRef.ts
@@ -51,7 +51,7 @@ export function annotateNamedFunctionRef(
 	if (!functionProperties) return undefined;
 
 	// Insert the type info into the AST and return
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
+
 	astHelper.insertAttribute(ast, 'type', functionProperties.returnType);
 	return functionProperties.returnType;
 }

--- a/src/typeInference/annotateNamedFunctionRef.ts
+++ b/src/typeInference/annotateNamedFunctionRef.ts
@@ -51,6 +51,7 @@ export function annotateNamedFunctionRef(
 	if (!functionProperties) return undefined;
 
 	// Insert the type info into the AST and return
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', functionProperties.returnType);
 	return functionProperties.returnType;
 }

--- a/src/typeInference/annotatePathExpr.ts
+++ b/src/typeInference/annotatePathExpr.ts
@@ -15,7 +15,6 @@ export function annotatePathExpr(ast: IAST, context: AnnotationContext): Sequenc
 		mult: SequenceMultiplicity.ZERO_OR_MORE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 	return seqType;
 }

--- a/src/typeInference/annotatePathExpr.ts
+++ b/src/typeInference/annotatePathExpr.ts
@@ -1,5 +1,6 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Inserting the node type of multiplicity zero or more to the ast;
@@ -8,12 +9,13 @@ import astHelper, { IAST } from '../parsing/astHelper';
  * @param ast the AST to be annotated.
  * @returns the inferred SequenceType
  */
-export function annotatePathExpr(ast: IAST): SequenceType {
+export function annotatePathExpr(ast: IAST, context: AnnotationContext): SequenceType {
 	const seqType = {
 		type: ValueType.NODE,
 		mult: SequenceMultiplicity.ZERO_OR_MORE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 	return seqType;
 }

--- a/src/typeInference/annotateQuantifiedExpr.ts
+++ b/src/typeInference/annotateQuantifiedExpr.ts
@@ -1,5 +1,6 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Annotate the ast by inserting boolean sequence type of exactly one multiplicity.
@@ -9,12 +10,13 @@ import astHelper, { IAST } from '../parsing/astHelper';
  * @param ast the ast node to be annotated.
  * @returns the annotated sequence type.
  */
-export function annotateQuantifiedExpr(ast: IAST): SequenceType {
+export function annotateQuantifiedExpr(ast: IAST, context: AnnotationContext): SequenceType {
 	const seqType = {
 		type: ValueType.XSBOOLEAN,
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;

--- a/src/typeInference/annotateQuantifiedExpr.ts
+++ b/src/typeInference/annotateQuantifiedExpr.ts
@@ -16,7 +16,6 @@ export function annotateQuantifiedExpr(ast: IAST, context: AnnotationContext): S
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;

--- a/src/typeInference/annotateRangeSequenceOperator.ts
+++ b/src/typeInference/annotateRangeSequenceOperator.ts
@@ -1,17 +1,19 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Inserts an integer sequence into the AST for the rangeSequenceExpr node.
  * @param ast the AST to be annotated.
  * @returns an integer sequence.
  */
-export function annotateRangeSequenceOperator(ast: IAST): SequenceType {
+export function annotateRangeSequenceOperator(ast: IAST, context: AnnotationContext): SequenceType {
 	const seqType = {
 		type: ValueType.XSINTEGER,
 		mult: SequenceMultiplicity.ONE_OR_MORE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;

--- a/src/typeInference/annotateRangeSequenceOperator.ts
+++ b/src/typeInference/annotateRangeSequenceOperator.ts
@@ -13,7 +13,6 @@ export function annotateRangeSequenceOperator(ast: IAST, context: AnnotationCont
 		mult: SequenceMultiplicity.ONE_OR_MORE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;

--- a/src/typeInference/annotateSequenceOperator.ts
+++ b/src/typeInference/annotateSequenceOperator.ts
@@ -28,7 +28,6 @@ export function annotateSequenceOperator(
 		};
 	}
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;

--- a/src/typeInference/annotateSequenceOperator.ts
+++ b/src/typeInference/annotateSequenceOperator.ts
@@ -13,9 +13,6 @@ export function annotateSequenceOperator(
 	length: number,
 	context: AnnotationContext
 ): SequenceType {
-	if (length === 0) {
-		return undefined;
-	}
 	const seqType = {
 		type: ValueType.ITEM,
 		mult: SequenceMultiplicity.ZERO_OR_MORE,

--- a/src/typeInference/annotateSequenceOperator.ts
+++ b/src/typeInference/annotateSequenceOperator.ts
@@ -13,10 +13,20 @@ export function annotateSequenceOperator(
 	length: number,
 	context: AnnotationContext
 ): SequenceType {
-	const seqType = {
-		type: ValueType.ITEM,
-		mult: SequenceMultiplicity.ZERO_OR_MORE,
-	};
+	let seqType;
+
+	if (length === 0) {
+		// We have an empty sequence here
+		seqType = {
+			type: ValueType.NODE,
+			mult: SequenceMultiplicity.ZERO_OR_MORE,
+		};
+	} else {
+		seqType = {
+			type: ValueType.ITEM,
+			mult: SequenceMultiplicity.ZERO_OR_MORE,
+		};
+	}
 
 	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);

--- a/src/typeInference/annotateSequenceOperator.ts
+++ b/src/typeInference/annotateSequenceOperator.ts
@@ -1,5 +1,6 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Inserts an item* type to the AST, as sequence operator can contain multiple different ITEM types.
@@ -7,7 +8,11 @@ import astHelper, { IAST } from '../parsing/astHelper';
  * @param ast the AST to be annotated.
  * @returns `SequenceType` of type ITEM with multiplicity of `ZERO_OR_MORE` or undefined in case we have an empty sequence.
  */
-export function annotateSequenceOperator(ast: IAST, length: number): SequenceType {
+export function annotateSequenceOperator(
+	ast: IAST,
+	length: number,
+	context: AnnotationContext
+): SequenceType {
 	if (length === 0) {
 		return undefined;
 	}
@@ -16,6 +21,7 @@ export function annotateSequenceOperator(ast: IAST, length: number): SequenceTyp
 		mult: SequenceMultiplicity.ZERO_OR_MORE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 
 	return seqType;

--- a/src/typeInference/annotateSetOperators.ts
+++ b/src/typeInference/annotateSetOperators.ts
@@ -1,5 +1,6 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Annotates the union, intersect and except operators with a sequence of nodes.
@@ -12,7 +13,8 @@ import astHelper, { IAST } from '../parsing/astHelper';
 export function annotateSetOperator(
 	ast: IAST,
 	left: SequenceType,
-	right: SequenceType
+	right: SequenceType,
+	context: AnnotationContext
 ): SequenceType | undefined {
 	if (!left || !right) return undefined;
 	if (left.type !== ValueType.NODE || right.type !== ValueType.NODE) {
@@ -21,40 +23,43 @@ export function annotateSetOperator(
 
 	switch (ast[0]) {
 		case 'unionOp':
-			return annotateUnionOperator(ast);
+			return annotateUnionOperator(ast, context);
 		case 'intersectOp':
-			return annotateIntersectOperator(ast);
+			return annotateIntersectOperator(ast, context);
 		case 'exceptOp':
-			return annotateExceptOperator(ast);
+			return annotateExceptOperator(ast, context);
 	}
 }
 
-function annotateUnionOperator(ast: IAST): SequenceType {
+function annotateUnionOperator(ast: IAST, context: AnnotationContext): SequenceType {
 	const seqType = {
 		type: ValueType.NODE,
 		mult: SequenceMultiplicity.ZERO_OR_MORE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 	return seqType;
 }
 
-function annotateIntersectOperator(ast: IAST): SequenceType {
+function annotateIntersectOperator(ast: IAST, context: AnnotationContext): SequenceType {
 	const seqType = {
 		type: ValueType.NODE,
 		mult: SequenceMultiplicity.ZERO_OR_MORE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 	return seqType;
 }
 
-function annotateExceptOperator(ast: IAST): SequenceType {
+function annotateExceptOperator(ast: IAST, context: AnnotationContext): SequenceType {
 	const seqType = {
 		type: ValueType.NODE,
 		mult: SequenceMultiplicity.ZERO_OR_MORE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 	return seqType;
 }

--- a/src/typeInference/annotateSetOperators.ts
+++ b/src/typeInference/annotateSetOperators.ts
@@ -38,7 +38,6 @@ function annotateUnionOperator(ast: IAST, context: AnnotationContext): SequenceT
 		mult: SequenceMultiplicity.ZERO_OR_MORE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 	return seqType;
 }
@@ -49,7 +48,6 @@ function annotateIntersectOperator(ast: IAST, context: AnnotationContext): Seque
 		mult: SequenceMultiplicity.ZERO_OR_MORE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 	return seqType;
 }
@@ -60,7 +58,6 @@ function annotateExceptOperator(ast: IAST, context: AnnotationContext): Sequence
 		mult: SequenceMultiplicity.ZERO_OR_MORE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 	return seqType;
 }

--- a/src/typeInference/annotateSetOperators.ts
+++ b/src/typeInference/annotateSetOperators.ts
@@ -1,3 +1,4 @@
+import isSubtypeOf from '../expressions/dataTypes/isSubtypeOf';
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
 import { AnnotationContext } from './annotateAST';
@@ -17,7 +18,7 @@ export function annotateSetOperator(
 	context: AnnotationContext
 ): SequenceType | undefined {
 	if (!left || !right) return undefined;
-	if (left.type !== ValueType.NODE || right.type !== ValueType.NODE) {
+	if (!isSubtypeOf(left.type, ValueType.NODE) || !isSubtypeOf(right.type, ValueType.NODE)) {
 		return undefined;
 	}
 

--- a/src/typeInference/annotateSimpleMapExpr.ts
+++ b/src/typeInference/annotateSimpleMapExpr.ts
@@ -15,7 +15,6 @@ export function annotateSimpleMapExpr(ast: IAST, context: AnnotationContext): Se
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 	return seqType;
 }

--- a/src/typeInference/annotateSimpleMapExpr.ts
+++ b/src/typeInference/annotateSimpleMapExpr.ts
@@ -1,5 +1,6 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Inserting the map type of multiplicity exactly one to the ast;
@@ -8,12 +9,13 @@ import astHelper, { IAST } from '../parsing/astHelper';
  * @param ast the AST to be annotated.
  * @returns the inferred SequenceType
  */
-export function annotateSimpleMapExpr(ast: IAST): SequenceType {
+export function annotateSimpleMapExpr(ast: IAST, context: AnnotationContext): SequenceType {
 	const seqType = {
 		type: ValueType.MAP,
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 	return seqType;
 }

--- a/src/typeInference/annotateStringConcatenateOperator.ts
+++ b/src/typeInference/annotateStringConcatenateOperator.ts
@@ -1,12 +1,17 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
-export function annotateStringConcatenateOperator(ast: IAST): SequenceType | undefined {
+export function annotateStringConcatenateOperator(
+	ast: IAST,
+	context: AnnotationContext
+): SequenceType | undefined {
 	const seqType = {
 		type: ValueType.XSSTRING,
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 	return seqType;
 }

--- a/src/typeInference/annotateStringConcatenateOperator.ts
+++ b/src/typeInference/annotateStringConcatenateOperator.ts
@@ -11,7 +11,6 @@ export function annotateStringConcatenateOperator(
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
 
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', seqType);
 	return seqType;
 }

--- a/src/typeInference/annotateUnaryOperator.ts
+++ b/src/typeInference/annotateUnaryOperator.ts
@@ -1,5 +1,5 @@
 import isSubtypeOf from '../expressions/dataTypes/isSubtypeOf';
-import { SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
 import { AnnotationContext } from './annotateAST';
 
@@ -34,7 +34,10 @@ export function annotateUnaryMinus(
 		return type;
 	}
 
-	return undefined;
+	return {
+		type: ValueType.XSDOUBLE,
+		mult: SequenceMultiplicity.EXACTLY_ONE,
+	};
 }
 
 /**

--- a/src/typeInference/annotateUnaryOperator.ts
+++ b/src/typeInference/annotateUnaryOperator.ts
@@ -29,7 +29,7 @@ export function annotateUnaryMinus(
 		};
 
 		// Attach the type to the AST
-		context.totalAnnotated[context.totalAnnotated.length - 1]++;
+
 		astHelper.insertAttribute(ast, 'type', type);
 		return type;
 	}
@@ -38,7 +38,7 @@ export function annotateUnaryMinus(
 		type: ValueType.XSDOUBLE,
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
+
 	astHelper.insertAttribute(ast, 'type', doubleType);
 	return doubleType;
 }
@@ -66,7 +66,6 @@ export function annotateUnaryPlus(
 			mult: valueType.mult,
 		};
 
-		context.totalAnnotated[context.totalAnnotated.length - 1]++;
 		astHelper.insertAttribute(ast, 'type', type);
 		return type;
 	}
@@ -75,7 +74,7 @@ export function annotateUnaryPlus(
 		type: ValueType.XSDOUBLE,
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
-	context.totalAnnotated[context.totalAnnotated.length - 1]++;
+
 	astHelper.insertAttribute(ast, 'type', doubleType);
 	return doubleType;
 }

--- a/src/typeInference/annotateUnaryOperator.ts
+++ b/src/typeInference/annotateUnaryOperator.ts
@@ -38,6 +38,7 @@ export function annotateUnaryMinus(
 		type: ValueType.XSDOUBLE,
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', doubleType);
 	return doubleType;
 }
@@ -74,6 +75,7 @@ export function annotateUnaryPlus(
 		type: ValueType.XSDOUBLE,
 		mult: SequenceMultiplicity.EXACTLY_ONE,
 	};
+	context.totalAnnotated[context.totalAnnotated.length - 1]++;
 	astHelper.insertAttribute(ast, 'type', doubleType);
 	return doubleType;
 }

--- a/src/typeInference/annotateUnaryOperator.ts
+++ b/src/typeInference/annotateUnaryOperator.ts
@@ -1,5 +1,5 @@
 import isSubtypeOf from '../expressions/dataTypes/isSubtypeOf';
-import { SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
 import { AnnotationContext } from './annotateAST';
 
@@ -34,7 +34,12 @@ export function annotateUnaryMinus(
 		return type;
 	}
 
-	return undefined;
+	const doubleType = {
+		type: ValueType.XSDOUBLE,
+		mult: SequenceMultiplicity.EXACTLY_ONE,
+	};
+	astHelper.insertAttribute(ast, 'type', doubleType);
+	return doubleType;
 }
 
 /**
@@ -65,5 +70,10 @@ export function annotateUnaryPlus(
 		return type;
 	}
 
-	return undefined;
+	const doubleType = {
+		type: ValueType.XSDOUBLE,
+		mult: SequenceMultiplicity.EXACTLY_ONE,
+	};
+	astHelper.insertAttribute(ast, 'type', doubleType);
+	return doubleType;
 }

--- a/src/typeInference/annotateUnaryOperator.ts
+++ b/src/typeInference/annotateUnaryOperator.ts
@@ -1,6 +1,7 @@
 import isSubtypeOf from '../expressions/dataTypes/isSubtypeOf';
 import { SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
+import { AnnotationContext } from './annotateAST';
 
 /**
  * Adds the unary minus operator type annotation to the AST
@@ -12,7 +13,8 @@ import astHelper, { IAST } from '../parsing/astHelper';
  */
 export function annotateUnaryMinus(
 	ast: IAST,
-	valueType: SequenceType | undefined
+	valueType: SequenceType | undefined,
+	context: AnnotationContext
 ): SequenceType | undefined {
 	// If we don't now the child type, we can't infer the current type
 	if (!valueType) {
@@ -27,6 +29,7 @@ export function annotateUnaryMinus(
 		};
 
 		// Attach the type to the AST
+		context.totalAnnotated[context.totalAnnotated.length - 1]++;
 		astHelper.insertAttribute(ast, 'type', type);
 		return type;
 	}
@@ -44,7 +47,8 @@ export function annotateUnaryMinus(
  */
 export function annotateUnaryPlus(
 	ast: IAST,
-	valueType: SequenceType | undefined
+	valueType: SequenceType | undefined,
+	context: AnnotationContext
 ): SequenceType | undefined {
 	if (!valueType) {
 		return undefined;
@@ -56,6 +60,7 @@ export function annotateUnaryPlus(
 			mult: valueType.mult,
 		};
 
+		context.totalAnnotated[context.totalAnnotated.length - 1]++;
 		astHelper.insertAttribute(ast, 'type', type);
 		return type;
 	}

--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -142,6 +142,11 @@ export type Options = {
 	logger?: Logger;
 
 	/**
+	 * Log queries which didn't get completely annotated
+	 */
+	logUnannotatedQueries?: boolean;
+
+	/**
 	 * Additional modules to import. Imported modules are always statically known
 	 */
 	moduleImports?: { [s: string]: string };

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -6,7 +6,7 @@ import annotateAst from 'fontoxpath/typeInference/annotateAST';
 
 function assertValueType(expression: string, expectedType: ValueType) {
 	const ast = parseExpression(expression, {});
-	annotateAst(ast, undefined);
+	annotateAst(ast, { staticContext: undefined, totalNodes: [], totalAnnotated: [] });
 
 	const queryBody = astHelper.followPath(ast, ['mainModule', 'queryBody']);
 	const resultType = astHelper.getAttribute(queryBody[1] as IAST, 'type') as SequenceType;

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -3,7 +3,7 @@ import { SequenceType, ValueType } from 'fontoxpath/expressions/dataTypes/Value'
 import StaticContext from 'fontoxpath/expressions/StaticContext';
 import astHelper from 'fontoxpath/parsing/astHelper';
 import parseExpression from 'fontoxpath/parsing/parseExpression';
-import annotateAst from 'fontoxpath/typeInference/annotateAST';
+import annotateAst, { countQueryBodyAnnotations } from 'fontoxpath/typeInference/annotateAST';
 
 /**
  *
@@ -271,6 +271,31 @@ describe('Annotating function call without context', () => {
 describe('Annotating inline functions', () => {
 	it('in line function test', () => {
 		assertValueType('function() {}', ValueType.FUNCTION, undefined);
+	});
+});
+
+describe('Annotation counting', () => {
+	it('correctly counts add expressions', () => {
+		const ast = parseExpression('2 + 1', {});
+		annotateAst(ast, {});
+		const [total, annotated] = countQueryBodyAnnotations(ast);
+		chai.assert.equal(total, annotated);
+	});
+	it('correctly counts unannotated expressions', () => {
+		const ast = parseExpression('$x + 1', {});
+		annotateAst(ast, {});
+		const [total, annotated] = countQueryBodyAnnotations(ast);
+		console.log(total, annotated);
+		chai.assert.equal(annotated, 1);
+		chai.assert.equal(total, 3);
+	});
+	it('correctly counts unannotated expressions 2', () => {
+		const ast = parseExpression('$b + math:sin($a)', {});
+		annotateAst(ast, {});
+		const [total, annotated] = countQueryBodyAnnotations(ast);
+		console.log(total, annotated);
+		chai.assert.equal(annotated, 0);
+		chai.assert.equal(total, 3);
 	});
 });
 

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -1,12 +1,12 @@
 import * as chai from 'chai';
 import { SequenceType, ValueType } from 'fontoxpath/expressions/dataTypes/Value';
-import astHelper, { IAST } from 'fontoxpath/parsing/astHelper';
+import astHelper from 'fontoxpath/parsing/astHelper';
 import parseExpression from 'fontoxpath/parsing/parseExpression';
 import annotateAst from 'fontoxpath/typeInference/annotateAST';
 
 function assertValueType(expression: string, expectedType: ValueType) {
 	const ast = parseExpression(expression, {});
-	annotateAst(ast, { staticContext: undefined, totalNodes: 0, totalAnnotated: [] });
+	annotateAst(ast, { staticContext: undefined });
 
 	const queryBody = astHelper.followPath(ast, ['mainModule', 'queryBody']);
 	const resultType = astHelper.getAttribute(queryBody, 'type') as SequenceType;

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -6,7 +6,7 @@ import annotateAst from 'fontoxpath/typeInference/annotateAST';
 
 function assertValueType(expression: string, expectedType: ValueType) {
 	const ast = parseExpression(expression, {});
-	annotateAst(ast, { staticContext: undefined, totalNodes: [], totalAnnotated: [] });
+	annotateAst(ast, { staticContext: undefined, totalNodes: 0, totalAnnotated: [] });
 
 	const queryBody = astHelper.followPath(ast, ['mainModule', 'queryBody']);
 	const resultType = astHelper.getAttribute(queryBody[1] as IAST, 'type') as SequenceType;

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -9,7 +9,7 @@ function assertValueType(expression: string, expectedType: ValueType) {
 	annotateAst(ast, { staticContext: undefined, totalNodes: 0, totalAnnotated: [] });
 
 	const queryBody = astHelper.followPath(ast, ['mainModule', 'queryBody']);
-	const resultType = astHelper.getAttribute(queryBody[1] as IAST, 'type') as SequenceType;
+	const resultType = astHelper.getAttribute(queryBody, 'type') as SequenceType;
 	if (!resultType) {
 		chai.assert.isTrue(!expectedType);
 	} else {

--- a/test/specs/parsing/registerCustomXPathFunction.tests.ts
+++ b/test/specs/parsing/registerCustomXPathFunction.tests.ts
@@ -809,7 +809,7 @@ describe('registerCustomXPathFunction', () => {
 			chai.assert.throws(
 				() =>
 					registerCustomXPathFunction(
-						'test:func',
+						'a-random-prefix-test:func',
 						[],
 						'this-type::does-not-exist',
 						() => {}


### PR DESCRIPTION
# Description

Give a short description of what was done in this pull request.

Closes #93 

# Changes

1. Convert the switch in annotateAst into a map. This allows us to use Object.keys() to get a list of all annotatable nodes.
2. Add a way to track how much of a query was annotated
3. Fix several small bugs encountered while measuring annotation count

# Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

# How Many Approvals?

* Approval of all (Controversial changes that change the entire project)