### PR TITLE
Move BinaryEvaluationFunction to BinaryOperator.ts

### DIFF
--- a/src/expressions/operators/arithmetic/BinaryOperator.ts
+++ b/src/expressions/operators/arithmetic/BinaryOperator.ts
@@ -2,15 +2,19 @@ import AtomicValue from '../../../expressions/dataTypes/AtomicValue';
 import castToType from '../../../expressions/dataTypes/castToType';
 import createAtomicValue from '../../../expressions/dataTypes/createAtomicValue';
 import isSubtypeOf from '../../../expressions/dataTypes/isSubtypeOf';
-import { ValueType, valueTypeToString } from '../../../expressions/dataTypes/Value';
+import { ValueType, valueTypeToString, ValueValue } from '../../../expressions/dataTypes/Value';
 import ExecutionParameters from '../../../expressions/ExecutionParameters';
-import { BinaryEvaluationFunction } from '../../../typeInference/binaryEvaluationFunction';
 import atomize from '../../dataTypes/atomize';
 import sequenceFactory from '../../dataTypes/sequenceFactory';
 import { SequenceType } from '../../dataTypes/Value';
 import DynamicContext from '../../DynamicContext';
 import Expression from '../../Expression';
 import { hash, operationMap, returnTypeMap } from './BinaryEvaluationFunctionMap';
+
+/**
+ * Lambda helper function to the binary operator
+ */
+export type BinaryEvaluationFunction = (left: ValueValue, right: ValueValue) => ValueValue;
 
 function determineReturnType(typeA: ValueType, typeB: ValueType): ValueType {
 	if (isSubtypeOf(typeA, ValueType.XSINTEGER) && isSubtypeOf(typeB, ValueType.XSINTEGER)) {

--- a/src/parsing/compileAstToExpression.ts
+++ b/src/parsing/compileAstToExpression.ts
@@ -24,6 +24,7 @@ import Literal from '../expressions/literals/Literal';
 import MapConstructor from '../expressions/maps/MapConstructor';
 import NamedFunctionRef from '../expressions/NamedFunctionRef';
 import BinaryOperator, {
+	BinaryEvaluationFunction,
 	generateBinaryOperatorFunction,
 } from '../expressions/operators/arithmetic/BinaryOperator';
 import Unary from '../expressions/operators/arithmetic/Unary';
@@ -64,7 +65,6 @@ import ElementConstructor from '../expressions/xquery/ElementConstructor';
 import PIConstructor from '../expressions/xquery/PIConstructor';
 import TextConstructor from '../expressions/xquery/TextConstructor';
 import TypeSwitchExpression from '../expressions/xquery/TypeSwitchExpression';
-import { BinaryEvaluationFunction } from '../typeInference/binaryEvaluationFunction';
 import astHelper, { IAST } from './astHelper';
 
 const COMPILATION_OPTIONS = {

--- a/src/typeInference/binaryEvaluationFunction.ts
+++ b/src/typeInference/binaryEvaluationFunction.ts
@@ -1,6 +1,0 @@
-import { ValueValue } from '../expressions/dataTypes/Value';
-
-/**
- * Lambda helper function to the binary operator
- */
-export type BinaryEvaluationFunction = (left: ValueValue, right: ValueValue) => ValueValue;


### PR DESCRIPTION
# Description

The binaryEvaluationFunction.ts file had the wrong file naming. While cleaning up this problem, it seemed like the contents of the file would fit better inside BinaryOperator.ts

Closes #106 

# Changes

1. BinaryEvaluationFunction has been moved from binaryEvaluationFunction.ts to BinaryOperator.ts

# Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

# How Many Approvals?

* 1 Approval (Small bugs/hot-fixes)