### PR TITLE
Refactor QName and magic number in BinOpEvalFunc

### DIFF
--- a/src/expressions/operators/arithmetic/BinaryEvaluationFunctionMap.ts
+++ b/src/expressions/operators/arithmetic/BinaryEvaluationFunctionMap.ts
@@ -19,6 +19,10 @@ import {
 	subtract as yearMonthDurationSubtract,
 } from '../../../expressions/dataTypes/valueTypes/YearMonthDuration';
 
+const SHIFT_FIRST_ARGUMENT_OF_HASH_BY = 20;
+const SHIFT_SECOND_ARGUMENT_OF_HASH_BY = 12;
+const SHIFT_THIRD_ARGUMENT_OF_HASH_BY = 8;
+
 /**
  * A hash function that is used to create the keys for the ruleMap.
  * @param left the ValueType of the left part of the operator
@@ -28,9 +32,9 @@ import {
  */
 export function hash(left: ValueType, right: ValueType, op: string): number {
 	return (
-		((left as number) << 20) +
-		((right as number) << 12) +
-		(op.charCodeAt(0) << 8) +
+		((left as number) << SHIFT_FIRST_ARGUMENT_OF_HASH_BY) +
+		((right as number) << SHIFT_SECOND_ARGUMENT_OF_HASH_BY) +
+		(op.charCodeAt(0) << SHIFT_THIRD_ARGUMENT_OF_HASH_BY) +
 		op.charCodeAt(1)
 	);
 }

--- a/src/typeInference/annotateArrowExpr.ts
+++ b/src/typeInference/annotateArrowExpr.ts
@@ -1,4 +1,5 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
+import QName from '../expressions/dataTypes/valueTypes/QName';
 import astHelper, { IAST } from '../parsing/astHelper';
 import { AnnotationContext } from './AnnotationContext';
 
@@ -24,24 +25,18 @@ export function annotateArrowExpr(
 		return undefined;
 	}
 
-	// Sometimes there is no prefix given, hence we need to check for that case and give an empty prefix
-	let functionName: string;
-	let functionPrefix: string;
-	if (func.length === 3) {
-		functionName = func[2] as string;
-		functionPrefix = func[1] as string;
-	} else {
-		functionName = func[1] as string;
-		functionPrefix = '';
-	}
+	// Get qualified function name
+	const qName: QName = astHelper.getQName(func);
+	const localName = qName.localName;
+	const prefix = qName.prefix;
 
 	const functionArguments = astHelper.getChildren(astHelper.getFirstChild(ast, 'arguments'), '*');
 
 	// Lookup the namespace URI
 	const resolvedName = annotationContext.staticContext.resolveFunctionName(
 		{
-			localName: functionName,
-			prefix: functionPrefix,
+			localName,
+			prefix,
 		},
 		functionArguments.length
 	);

--- a/src/typeInference/annotateFunctionCall.ts
+++ b/src/typeInference/annotateFunctionCall.ts
@@ -1,4 +1,5 @@
 import { SequenceType } from '../expressions/dataTypes/Value';
+import QName from '../expressions/dataTypes/valueTypes/QName';
 import astHelper, { IAST } from '../parsing/astHelper';
 import { AnnotationContext } from './AnnotationContext';
 
@@ -17,23 +18,18 @@ export function annotateFunctionCall(
 	// We need the context to lookup the function information
 	if (!annotationContext || !annotationContext.staticContext) return undefined;
 
-	const func = astHelper.getFirstChild(ast, 'functionName');
-	let functionName: string;
-	let functionPrefix: string;
-	if (func.length === 3) {
-		functionName = func[2] as string;
-		functionPrefix = func[1] as string;
-	} else {
-		functionName = func[1] as string;
-		functionPrefix = '';
-	}
+	// Get qualified function name
+	const qName: QName = astHelper.getQName(astHelper.getFirstChild(ast, 'functionName'));
+	const localName = qName.localName;
+	const prefix = qName.prefix;
+
 	const functionArguments = astHelper.getChildren(astHelper.getFirstChild(ast, 'arguments'), '*');
 
 	// Lookup the namespace URI
 	const resolvedName = annotationContext.staticContext.resolveFunctionName(
 		{
-			localName: functionName,
-			prefix: functionPrefix,
+			localName,
+			prefix,
 		},
 		functionArguments.length
 	);

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -4,12 +4,10 @@ import {
 	SequenceType,
 	ValueType,
 } from 'fontoxpath/expressions/dataTypes/Value';
-import StaticContext from 'fontoxpath/expressions/StaticContext';
 import astHelper from 'fontoxpath/parsing/astHelper';
 import parseExpression from 'fontoxpath/parsing/parseExpression';
 import annotateAst, { countQueryBodyAnnotations } from 'fontoxpath/typeInference/annotateAST';
 import { AnnotationContext } from 'fontoxpath/typeInference/AnnotationContext';
-import { type } from 'os';
 
 /**
  *
@@ -270,7 +268,7 @@ describe('Annotating function call without context', () => {
 	it('array function call without context', () => {
 		assertValueType('array:size([])', undefined, undefined);
 	});
-	it('array function call without context', () => {
+	it('name function call without context', () => {
 		assertValueType('fn:concat#2', undefined, undefined);
 	});
 });


### PR DESCRIPTION
## Description

Use helper function to resolve QName

Closes #104 
Closes #105 

## Changes

1. annotateArrowExpr
2. annotateFunctionCall
3. Remove the magic numbers in the hashing function of BinaryEvaluationFunction

## Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

## How Many Approvals?

* 1 Approval (Small bugs/hot-fixes)