### PR TITLE
Add beta tag to Options.ts

### DIFF
--- a/src/types/Options.ts
+++ b/src/types/Options.ts
@@ -63,6 +63,7 @@ export type Options = {
 	/**
 	 * Whether or not the AST should get annotated after parsing an expression. The annotation adds
 	 * additional type information to the AST.
+	 * @beta
 	 */
 	annotateAst?: boolean;
 


### PR DESCRIPTION
# Description

Since the annotateAst option is still in beta it should get marked as beta.

Closes #112 

# Changes

1. Add `@beta` tag to annoteAst in Options.ts

# Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

# How Many Approvals?

* 1 Approval (Small bugs/hot-fixes)