### PR TITLE
Remove item()* annotations from AST

### DIFF
--- a/src/typeInference/annotateArrayConstructor.ts
+++ b/src/typeInference/annotateArrayConstructor.ts
@@ -1,6 +1,5 @@
 import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
-import { AnnotationContext } from './AnnotationContext';
 
 /**
  * Inserting the array type of multiplicity exactly one to the ast;

--- a/src/typeInference/annotateArrowExpr.ts
+++ b/src/typeInference/annotateArrowExpr.ts
@@ -13,21 +13,21 @@ import { AnnotationContext } from './AnnotationContext';
  */
 export function annotateArrowExpr(ast: IAST, annotationContext: AnnotationContext): SequenceType {
 	// We need the context to lookup the function information
-	const itemReturn = {
-		type: ValueType.ITEM,
-		mult: SequenceMultiplicity.EXACTLY_ONE,
-	};
 	if (!annotationContext || !annotationContext.staticContext) {
-		astHelper.insertAttribute(ast, 'type', itemReturn);
-		return itemReturn;
+		return {
+			type: ValueType.ITEM,
+			mult: SequenceMultiplicity.ZERO_OR_MORE,
+		};
 	}
 
 	const func = astHelper.getFirstChild(ast, 'EQName');
 
 	// There may be no name for the function
 	if (!func) {
-		astHelper.insertAttribute(ast, 'type', itemReturn);
-		return itemReturn;
+		return {
+			type: ValueType.ITEM,
+			mult: SequenceMultiplicity.ZERO_OR_MORE,
+		};
 	}
 
 	// Get qualified function name
@@ -48,8 +48,10 @@ export function annotateArrowExpr(ast: IAST, annotationContext: AnnotationContex
 
 	// If we did not find the function, we return item()*
 	if (!resolvedName) {
-		astHelper.insertAttribute(ast, 'type', itemReturn);
-		return itemReturn;
+		return {
+			type: ValueType.ITEM,
+			mult: SequenceMultiplicity.ZERO_OR_MORE,
+		};
 	}
 
 	// Lookup the function properties (return type)
@@ -62,8 +64,10 @@ export function annotateArrowExpr(ast: IAST, annotationContext: AnnotationContex
 
 	// If we did not find the returnType, we return item()*
 	if (!functionProps) {
-		astHelper.insertAttribute(ast, 'type', itemReturn);
-		return itemReturn;
+		return {
+			type: ValueType.ITEM,
+			mult: SequenceMultiplicity.ZERO_OR_MORE,
+		};
 	}
 
 	// If we found a returnType, we annotate the AST with it

--- a/src/typeInference/annotateBinaryOperator.ts
+++ b/src/typeInference/annotateBinaryOperator.ts
@@ -29,12 +29,10 @@ export function annotateBinOp(
 ): SequenceType {
 	// If we don't have the left and right type, we cannot infer the current type
 	if (!left || !right) {
-		const itemReturn = {
+		return {
 			type: ValueType.ITEM,
 			mult: SequenceMultiplicity.ZERO_OR_MORE,
 		};
-		astHelper.insertAttribute(ast, 'type', itemReturn);
-		return itemReturn;
 	}
 
 	// TODO: Fix this hack (pathExpr returns a node in 1 case, which cannot be added to an integer)

--- a/src/typeInference/annotateContextItemExpr.ts
+++ b/src/typeInference/annotateContextItemExpr.ts
@@ -9,10 +9,8 @@ import astHelper, { IAST } from '../parsing/astHelper';
  */
 export function annotateContextItemExpr(ast: IAST): SequenceType {
 	// TODO: What type should be returned here?
-	const itemReturn = {
+	return {
 		type: ValueType.ITEM,
 		mult: SequenceMultiplicity.ZERO_OR_MORE,
 	};
-	astHelper.insertAttribute(ast, 'type', itemReturn);
-	return itemReturn;
 }

--- a/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
+++ b/src/typeInference/annotateDynamicFunctionInvocationExpr.ts
@@ -9,10 +9,8 @@ import astHelper, { IAST } from '../parsing/astHelper';
  * @returns A SequenceType of item()*.
  */
 export function annotateDynamicFunctionInvocationExpr(ast: IAST): SequenceType {
-	const itemReturn = {
+	return {
 		type: ValueType.ITEM,
 		mult: SequenceMultiplicity.ZERO_OR_MORE,
 	};
-	astHelper.insertAttribute(ast, 'type', itemReturn);
-	return itemReturn;
 }

--- a/src/typeInference/annotateFunctionCall.ts
+++ b/src/typeInference/annotateFunctionCall.ts
@@ -15,15 +15,12 @@ export function annotateFunctionCall(
 	ast: IAST,
 	annotationContext: AnnotationContext
 ): SequenceType {
-	const itemReturn = {
-		type: ValueType.ITEM,
-		mult: SequenceMultiplicity.EXACTLY_ONE,
-	};
-
 	// We need the context to lookup the function information
 	if (!annotationContext || !annotationContext.staticContext) {
-		astHelper.insertAttribute(ast, 'type', itemReturn);
-		return itemReturn;
+		return {
+			type: ValueType.ITEM,
+			mult: SequenceMultiplicity.ZERO_OR_MORE,
+		};
 	}
 
 	// Get qualified function name
@@ -43,8 +40,10 @@ export function annotateFunctionCall(
 	);
 
 	if (!resolvedName) {
-		astHelper.insertAttribute(ast, 'type', itemReturn);
-		return itemReturn;
+		return {
+			type: ValueType.ITEM,
+			mult: SequenceMultiplicity.ZERO_OR_MORE,
+		};
 	}
 
 	// Lookup the function properties (return type)
@@ -54,10 +53,12 @@ export function annotateFunctionCall(
 		functionArguments.length
 	);
 
-	// If we did not find a returnType, we annotate with item()*
+	// If we did not find a returnType, we return item()*
 	if (!functionProps) {
-		astHelper.insertAttribute(ast, 'type', itemReturn);
-		return itemReturn;
+		return {
+			type: ValueType.ITEM,
+			mult: SequenceMultiplicity.ZERO_OR_MORE,
+		};
 	}
 
 	// If we found a return type, we annotate the AST with it

--- a/src/typeInference/annotateIfThenElseExpr.ts
+++ b/src/typeInference/annotateIfThenElseExpr.ts
@@ -16,19 +16,18 @@ export function annotateIfThenElseExpr(
 	elseClause: SequenceType,
 	thenClause: SequenceType
 ): SequenceType {
-	const itemReturn = {
-		type: ValueType.ITEM,
-		mult: SequenceMultiplicity.ZERO_OR_MORE,
-	};
-
 	if (!elseClause || !thenClause) {
-		astHelper.insertAttribute(ast, 'type', itemReturn);
-		return itemReturn;
+		return {
+			type: ValueType.ITEM,
+			mult: SequenceMultiplicity.ZERO_OR_MORE,
+		};
 	}
 	if (elseClause.type === thenClause.type && elseClause.mult === thenClause.mult) {
 		astHelper.insertAttribute(ast, 'type', elseClause);
 		return elseClause;
 	}
-	astHelper.insertAttribute(ast, 'type', itemReturn);
-	return itemReturn;
+	return {
+		type: ValueType.ITEM,
+		mult: SequenceMultiplicity.ZERO_OR_MORE,
+	};
 }

--- a/src/typeInference/annotateNamedFunctionRef.ts
+++ b/src/typeInference/annotateNamedFunctionRef.ts
@@ -15,15 +15,12 @@ export function annotateNamedFunctionRef(
 	ast: IAST,
 	annotationContext: AnnotationContext
 ): SequenceType {
-	const itemReturn = {
-		type: ValueType.ITEM,
-		mult: SequenceMultiplicity.EXACTLY_ONE,
-	};
-
 	// Can't find info about the function without the context.
 	if (!annotationContext || !annotationContext.staticContext) {
-		astHelper.insertAttribute(ast, 'type', itemReturn);
-		return itemReturn;
+		return {
+			type: ValueType.ITEM,
+			mult: SequenceMultiplicity.ZERO_OR_MORE,
+		};
 	}
 
 	// Get qualified function name
@@ -44,8 +41,10 @@ export function annotateNamedFunctionRef(
 		);
 
 		if (!functionName) {
-			astHelper.insertAttribute(ast, 'type', itemReturn);
-			return itemReturn;
+			return {
+				type: ValueType.ITEM,
+				mult: SequenceMultiplicity.ZERO_OR_MORE,
+			};
 		}
 
 		localName = functionName.localName;
@@ -58,8 +57,10 @@ export function annotateNamedFunctionRef(
 
 	// If there are no function properties, there is no type inference
 	if (!functionProperties) {
-		astHelper.insertAttribute(ast, 'type', itemReturn);
-		return itemReturn;
+		return {
+			type: ValueType.ITEM,
+			mult: SequenceMultiplicity.ZERO_OR_MORE,
+		};
 	}
 
 	// Insert the type info into the AST and return

--- a/src/typeInference/annotateTypeSwitchOperator.ts
+++ b/src/typeInference/annotateTypeSwitchOperator.ts
@@ -24,7 +24,10 @@ export function annotateTypeSwitchOperator(
 ): SequenceType | undefined {
 	// TODO: check this case in more detail (anyKindTest for example returns undefined)
 	if (!argumentType || caseClausesReturns.includes(undefined)) {
-		return undefined;
+		return {
+			type: ValueType.ITEM,
+			mult: SequenceMultiplicity.ZERO_OR_MORE,
+		};
 	}
 	// Get the types of the conditions from the clauses
 	const caseClausesConditions = astHelper.getChildren(ast, 'typeswitchExprCaseClause');
@@ -58,7 +61,10 @@ export function annotateTypeSwitchOperator(
 				}
 			// This should never be reached
 			default:
-				return undefined;
+				return {
+					type: ValueType.ITEM,
+					mult: SequenceMultiplicity.ZERO_OR_MORE,
+				};
 		}
 	}
 	// Return the type from the default case
@@ -84,11 +90,10 @@ function checkComparison(
 	// TODO: check this behaviours here as well (happens together with the TODO above)
 	// If there is no atomicType, we cannot compare the types and hence cannot infer the type and return item()*
 	if (!firstChild) {
-		const itemReturn = {
+		return {
 			type: ValueType.ITEM,
-			mult: SequenceMultiplicity.EXACTLY_ONE,
+			mult: SequenceMultiplicity.ZERO_OR_MORE,
 		};
-		return itemReturn;
 	}
 	// Since the type in the atomicType is stored as a string, we need to fetch the data and compare it against our argumentType
 	if (

--- a/src/typeInference/annotateUnaryLookup.ts
+++ b/src/typeInference/annotateUnaryLookup.ts
@@ -3,10 +3,8 @@ import astHelper, { IAST } from '../parsing/astHelper';
 
 // TODO: Annotation not yet implemented. How to lookup the NCName and get the type to be returned.
 export function annotateUnaryLookup(ast: IAST, ncName: IAST): SequenceType {
-	const itemReturn = {
+	return {
 		type: ValueType.ITEM,
 		mult: SequenceMultiplicity.ZERO_OR_MORE,
 	};
-	astHelper.insertAttribute(ast, 'type', itemReturn);
-	return itemReturn;
 }

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -64,7 +64,7 @@ describe('Annotating unary expressions', () => {
 
 describe('Annotate unary lookup', () => {
 	it('unary look up test', () => {
-		assertValueType('map{"num":1}[?num]', ValueType.ITEM, undefined, [
+		assertValueType('map{"num":1}[?num]', undefined, undefined, [
 			'mainModule',
 			'queryBody',
 			'pathExpr',
@@ -159,7 +159,7 @@ describe('Annotate arrowExpr', () => {
 
 describe('Annotate dynamic function invocation expression test', () => {
 	it('dynamic function invocation', () => {
-		assertValueType('$f()', ValueType.ITEM, undefined, [
+		assertValueType('$f()', undefined, undefined, [
 			'mainModule',
 			'queryBody',
 			'pathExpr',
@@ -336,7 +336,7 @@ describe('Annotation counting', () => {
 		annotateAst(ast, context);
 		const [total, annotated] = countQueryBodyAnnotations(ast);
 		console.log(total, annotated);
-		chai.assert.equal(annotated, 3);
+		chai.assert.equal(annotated, 2);
 		chai.assert.equal(total, 5);
 	});
 });


### PR DESCRIPTION
# Description

Removes the item()* annotations from the AST. Now the SequenceType is only returned.

## Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

## How Many Approvals?

* 2 Approvals (Normal features and bugs)