### PR TITLE
BinaryOperators always returns XSNUMERIC

### DIFF
--- a/src/typeInference/annotateBinaryOperator.ts
+++ b/src/typeInference/annotateBinaryOperator.ts
@@ -30,8 +30,8 @@ export function annotateBinOp(
 	// If we don't have the left and right type, we cannot infer the current type
 	if (!left || !right) {
 		return {
-			type: ValueType.ITEM,
-			mult: SequenceMultiplicity.ZERO_OR_MORE,
+			type: ValueType.XSNUMERIC,
+			mult: SequenceMultiplicity.EXACTLY_ONE,
 		};
 	}
 

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -397,7 +397,7 @@ describe('annotating varRef', () => {
 		assertValueType('$x + 1', ValueType.XSINTEGER, context);
 	});
 	it('annotate varRef not in context', () => {
-		assertValueType('$x + $l', ValueType.ITEM, context);
+		assertValueType('$x + $l', ValueType.XSNUMERIC, context);
 	});
 	it('annotate varRef throws when types incorrect', () => {
 		chai.assert.throws(() => assertValueType('$x + $z', undefined, context));


### PR DESCRIPTION
# Description

Since Marijn merged too early, here is another pull request. It makes BinaryOperators always return a numeric value.

## Delete branch

- Yes 