### PR TITLE
Resolve node return type conversation at Fonto Pull 357

### DIFF
--- a/src/typeInference/annotateBinaryOperator.ts
+++ b/src/typeInference/annotateBinaryOperator.ts
@@ -36,7 +36,11 @@ export function annotateBinOp(
 	}
 
 	// TODO: Fix this hack (pathExpr returns a node in 1 case, which cannot be added to an integer)
-	if (left.type === ValueType.NODE || right.type === ValueType.NODE) return undefined;
+	if (left.type === ValueType.NODE || right.type === ValueType.NODE)
+		return {
+			type: ValueType.XSNUMERIC,
+			mult: SequenceMultiplicity.EXACTLY_ONE,
+		};
 	if (left.type === ValueType.ITEM || right.type === ValueType.ITEM) return undefined;
 	if (left.type === ValueType.XSANYATOMICTYPE || right.type === ValueType.XSANYATOMICTYPE)
 		return undefined;


### PR DESCRIPTION
## Description

Give a short description of what was done in this pull request.

Closes #`id of branch`

## Changes

1. When to nodes are being passed as left and right operands, return a numeric type but not going to insert to AST.

Sources:
```
result is always xs:numeric: https://xpath.playground.fontoxml.com/?mode=1&variables=%7B%7D&xml=%3Ca%2F%3E&xpath=%28%3Ca%3E1%3C%2Fa%3E+%2B+%3Ca%3E2.0%3C%2Fa%3E%29++instance+of+xs%3Anumeric&context=
```

## Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

## How Many Approvals?

* 1 Approval (Small bugs/hot-fixes)