### PR TITLE
117 implement simple map expr

### DIFF
--- a/src/expressions/operators/arithmetic/BinaryOperator.ts
+++ b/src/expressions/operators/arithmetic/BinaryOperator.ts
@@ -300,17 +300,6 @@ class BinaryOperator extends Expression {
 			executionParameters
 		);
 
-		// We could infer all the necessary type information to do an early return
-		if (this._evaluateFunction && this.type) {
-			const firstValue = firstValueSequence.first();
-			const secondValueSequence = atomize(
-				this._secondValueExpr.evaluateMaybeStatically(dynamicContext, executionParameters),
-				executionParameters
-			);
-			const secondValue = secondValueSequence.first();
-			return sequenceFactory.singleton(this._evaluateFunction(firstValue, secondValue));
-		}
-
 		return firstValueSequence.mapAll((firstValues) => {
 			if (firstValues.length === 0) {
 				// Shortcut, if the first part is empty, we can return empty.
@@ -336,6 +325,13 @@ class BinaryOperator extends Expression {
 
 				const firstValue = firstValues[0];
 				const secondValue = secondValues[0];
+
+				// We could infer all the necessary type information to do an early return
+				if (this._evaluateFunction && this.type) {
+					return sequenceFactory.singleton(
+						this._evaluateFunction(firstValue, secondValue)
+					);
+				}
 
 				const prefabOperator = getBinaryPrefabOperator(
 					firstValue.type,

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -323,7 +323,12 @@ const annotationFunctions: {
 	},
 	// Maps
 	simpleMapExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
-		return annotateSimpleMapExpr(ast, context, annotate);
+		const pathExpressions: IAST[] = astHelper.getChildren(ast, 'pathExpr');
+		let lastType;
+		for (let i = 0; i < pathExpressions.length; i++) {
+			lastType = annotate(pathExpressions[i], context);
+		}
+		return annotateSimpleMapExpr(ast, context, lastType);
 	},
 	mapConstructor: (ast: IAST, context: AnnotationContext): SequenceType => {
 		astHelper.getChildren(ast, 'mapConstructorEntry').map((keyValuePair) => ({

--- a/src/typeInference/annotateAST.ts
+++ b/src/typeInference/annotateAST.ts
@@ -174,8 +174,8 @@ const annotationFunctions: {
 	// Sequences
 	sequenceExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
 		const children = astHelper.getChildren(ast, '*');
-		children.map((a) => annotate(a, context));
-		return annotateSequenceOperator(ast, children.length);
+		const types = children.map((a) => annotate(a, context));
+		return annotateSequenceOperator(ast, children.length, children, types);
 	},
 
 	// Set operations (union, intersect, except)
@@ -323,7 +323,7 @@ const annotationFunctions: {
 	},
 	// Maps
 	simpleMapExpr: (ast: IAST, context: AnnotationContext): SequenceType => {
-		return annotateSimpleMapExpr(ast, context);
+		return annotateSimpleMapExpr(ast, context, annotate);
 	},
 	mapConstructor: (ast: IAST, context: AnnotationContext): SequenceType => {
 		astHelper.getChildren(ast, 'mapConstructorEntry').map((keyValuePair) => ({

--- a/src/typeInference/annotateFlworExpression.ts
+++ b/src/typeInference/annotateFlworExpression.ts
@@ -178,7 +178,7 @@ function annotateOrderByClause(ast: IAST, annotationContext: AnnotationContext):
  * @param array the array to be filtered
  * @returns the filtered array
  */
-function filterOnUniqueObjects(array: SequenceType[]): SequenceType[] {
+export function filterOnUniqueObjects(array: SequenceType[]): SequenceType[] {
 	return array.filter(
 		(current, index, arrayCopy) =>
 			arrayCopy.findIndex(

--- a/src/typeInference/annotatePathExpr.ts
+++ b/src/typeInference/annotatePathExpr.ts
@@ -33,10 +33,7 @@ function annotateStep(step: IAST): SequenceType {
 	const lastChild = children[children.length - 1];
 	switch (lastChild[0]) {
 		case 'filterExpr': {
-			seqType = astHelper.getAttribute(
-				astHelper.followPath(lastChild, ['*']),
-				'type'
-			) as SequenceType;
+			seqType = astHelper.getAttribute(astHelper.followPath(lastChild, ['*']), 'type');
 			break;
 		}
 		case 'xpathAxis':

--- a/src/typeInference/annotatePathExpr.ts
+++ b/src/typeInference/annotatePathExpr.ts
@@ -19,7 +19,7 @@ export function annotatePathExpr(ast: IAST): SequenceType {
 	let retType;
 	for (const step of steps) {
 		annotateStep(step);
-		retType = astHelper.getAttribute(step, 'type') as SequenceType;
+		retType = astHelper.getAttribute(step, 'type');
 	}
 
 	if (retType === undefined || retType === null) {

--- a/src/typeInference/annotateSequenceOperator.ts
+++ b/src/typeInference/annotateSequenceOperator.ts
@@ -24,15 +24,15 @@ export function annotateSequenceOperator(
 			mult: SequenceMultiplicity.ZERO_OR_MORE,
 		};
 	} else {
-		const contatinsUndefined = types.includes(undefined);
-		if (contatinsUndefined) {
+		const contatinsUndefinedOrNull = types.includes(undefined) || types.includes(null);
+		if (contatinsUndefinedOrNull) {
 			seqType = {
 				type: ValueType.ITEM,
 				mult: SequenceMultiplicity.ZERO_OR_MORE,
 			};
 		} else {
 			const uniqueTypes = filterOnUniqueObjects(types);
-			if (uniqueTypes.length > 1 && !contatinsUndefined) {
+			if (uniqueTypes.length > 1 && !contatinsUndefinedOrNull) {
 				seqType = {
 					type: ValueType.ITEM,
 					mult: SequenceMultiplicity.ZERO_OR_MORE,

--- a/src/typeInference/annotateSequenceOperator.ts
+++ b/src/typeInference/annotateSequenceOperator.ts
@@ -32,7 +32,7 @@ export function annotateSequenceOperator(
 			};
 		} else {
 			const uniqueTypes = filterOnUniqueObjects(types);
-			if (uniqueTypes.length > 1 && !contatinsUndefinedOrNull) {
+			if (uniqueTypes.length > 1) {
 				seqType = {
 					type: ValueType.ITEM,
 					mult: SequenceMultiplicity.ZERO_OR_MORE,

--- a/src/typeInference/annotateSequenceOperator.ts
+++ b/src/typeInference/annotateSequenceOperator.ts
@@ -24,15 +24,15 @@ export function annotateSequenceOperator(
 			mult: SequenceMultiplicity.ZERO_OR_MORE,
 		};
 	} else {
-		const contatinsUndefinedOrNull = types.includes(undefined) || types.includes(null);
-		if (contatinsUndefinedOrNull) {
+		const contatinsUndefined = types.includes(undefined);
+		if (contatinsUndefined) {
 			seqType = {
 				type: ValueType.ITEM,
 				mult: SequenceMultiplicity.ZERO_OR_MORE,
 			};
 		} else {
 			const uniqueTypes = filterOnUniqueObjects(types);
-			if (uniqueTypes.length > 1 && !contatinsUndefinedOrNull) {
+			if (uniqueTypes.length > 1 && !contatinsUndefined) {
 				seqType = {
 					type: ValueType.ITEM,
 					mult: SequenceMultiplicity.ZERO_OR_MORE,

--- a/src/typeInference/annotateSequenceOperator.ts
+++ b/src/typeInference/annotateSequenceOperator.ts
@@ -3,10 +3,11 @@ import astHelper, { IAST } from '../parsing/astHelper';
 import { filterOnUniqueObjects } from './annotateFlworExpression';
 
 /**
- * Inserts an item()* type to the AST, as sequence operator can contain multiple different ITEM types.
+ * If every type of alle the elements are the same we annotate the ast with that type *.
+ * else inserts an item()* type to the AST, as sequence operator can contain multiple different ITEM types.
  * If we have an empty sequence, we return a Node type.
  * @param ast the AST to be annotated.
- * @returns `SequenceType` of type ITEM with multiplicity of `ZERO_OR_MORE` or NODE in case we have an empty sequence.
+ * @returns `SequenceType` with multiplicity of `ZERO_OR_MORE`.
  */
 export function annotateSequenceOperator(
 	ast: IAST,

--- a/src/typeInference/annotateSimpleMapExpr.ts
+++ b/src/typeInference/annotateSimpleMapExpr.ts
@@ -1,4 +1,9 @@
-import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import {
+	SequenceMultiplicity,
+	SequenceType,
+	sequenceTypeToString,
+	ValueType,
+} from '../expressions/dataTypes/Value';
 import astHelper, { IAST } from '../parsing/astHelper';
 import { AnnotationContext } from './AnnotationContext';
 
@@ -18,11 +23,13 @@ export function annotateSimpleMapExpr(
 	for (let i = 0; i < pathExpressions.length; i++) {
 		lastType = annotate(pathExpressions[i], context);
 	}
-	if (lastType) {
+	// throw Error(sequenceTypeToString(lastType));
+	if (lastType !== undefined && lastType !== null) {
 		const sequenceType: SequenceType = {
 			type: lastType.type,
 			mult: SequenceMultiplicity.ZERO_OR_MORE,
 		};
+		astHelper.insertAttribute(ast, 'type', lastType);
 		return sequenceType;
 	} else {
 		return { type: ValueType.ITEM, mult: SequenceMultiplicity.ZERO_OR_MORE };

--- a/src/typeInference/annotateSimpleMapExpr.ts
+++ b/src/typeInference/annotateSimpleMapExpr.ts
@@ -23,7 +23,6 @@ export function annotateSimpleMapExpr(
 	for (let i = 0; i < pathExpressions.length; i++) {
 		lastType = annotate(pathExpressions[i], context);
 	}
-	// throw Error(sequenceTypeToString(lastType));
 	if (lastType !== undefined && lastType !== null) {
 		const sequenceType: SequenceType = {
 			type: lastType.type,

--- a/src/typeInference/annotateSimpleMapExpr.ts
+++ b/src/typeInference/annotateSimpleMapExpr.ts
@@ -1,5 +1,5 @@
-import { SequenceType } from '../expressions/dataTypes/Value';
-import { IAST } from '../parsing/astHelper';
+import { SequenceMultiplicity, SequenceType, ValueType } from '../expressions/dataTypes/Value';
+import astHelper, { IAST } from '../parsing/astHelper';
 import { AnnotationContext } from './AnnotationContext';
 
 /**
@@ -8,13 +8,23 @@ import { AnnotationContext } from './AnnotationContext';
  * @param ast the AST to be annotated.
  * @returns the inferred SequenceType
  */
-export function annotateSimpleMapExpr(ast: IAST, context: AnnotationContext): SequenceType {
-	// const seqType = {
-	// 	type: ValueType.MAP,
-	// 	mult: SequenceMultiplicity.EXACTLY_ONE,
-	// };
-
-	// astHelper.insertAttribute(ast, 'type', seqType);
-	// return seqType;
-	return undefined;
+export function annotateSimpleMapExpr(
+	ast: IAST,
+	context: AnnotationContext,
+	annotate: (ast: IAST, context: AnnotationContext) => SequenceType
+): SequenceType {
+	const pathExpressions: IAST[] = astHelper.getChildren(ast, 'pathExpr');
+	let lastType;
+	for (let i = 0; i < pathExpressions.length; i++) {
+		lastType = annotate(pathExpressions[i], context);
+	}
+	if (lastType) {
+		const sequenceType: SequenceType = {
+			type: lastType.type,
+			mult: SequenceMultiplicity.ZERO_OR_MORE,
+		};
+		return sequenceType;
+	} else {
+		return { type: ValueType.ITEM, mult: SequenceMultiplicity.ZERO_OR_MORE };
+	}
 }

--- a/src/typeInference/annotateSimpleMapExpr.ts
+++ b/src/typeInference/annotateSimpleMapExpr.ts
@@ -16,13 +16,8 @@ import { AnnotationContext } from './AnnotationContext';
 export function annotateSimpleMapExpr(
 	ast: IAST,
 	context: AnnotationContext,
-	annotate: (ast: IAST, context: AnnotationContext) => SequenceType
+	lastType: SequenceType
 ): SequenceType {
-	const pathExpressions: IAST[] = astHelper.getChildren(ast, 'pathExpr');
-	let lastType;
-	for (let i = 0; i < pathExpressions.length; i++) {
-		lastType = annotate(pathExpressions[i], context);
-	}
 	if (lastType !== undefined && lastType !== null) {
 		const sequenceType: SequenceType = {
 			type: lastType.type,

--- a/test/assets/unrunnableTestCases.csv
+++ b/test/assets/unrunnableTestCases.csv
@@ -4189,3 +4189,8 @@ fo-test-array-subarray-006,Error: FOAY0001: subarray start out of bounds.
 fo-test-array-subarray-007,Error: FOAY0001: subarray start out of bounds.
 fo-test-array-fold-right-003,AssertionError: Expected XPath          array:fold-right([1,2,3], [], function($x, $y){[$x, $y]})        to (deep equally) resolve to [1, [2, [3, []]]]: expected false to be true
 fo-test-array-sort-002,Error: XPST0017: Function array:sort with arity of 3 not registered. Did you mean "Q{http://www.w3.org/2005/xpath-functions/array}sort (array(*))", "Q{http://www.w3.org/2001/XMLSchema}short (xs:anyAtomicType?)" or "Q{http://www.w3.org/2005/xpath-functions/math}sqrt (xs:double?)"?
+K-NumericAdd-37,AssertionError: expected [Function] to throw an error
+K-NumericAdd-39,AssertionError: Expected executing the XPath "1 + (1, 2)" to resolve to one of the expected results, but got AssertionError: expected [Function] to throw an error, AssertionError: expected [Function] to throw an error.
+K2-NumericAdd-1,AssertionError: expected [Function] to throw an error
+K2-NodeTest-37,AssertionError: expected [Function] to throw error matching /XPTY0018/ but got 'Cannot read property \'type\' of null'
+XPTY0004_46,AssertionError: expected [Function] to throw an error

--- a/test/assets/unrunnableTestCases.csv
+++ b/test/assets/unrunnableTestCases.csv
@@ -4189,8 +4189,3 @@ fo-test-array-subarray-006,Error: FOAY0001: subarray start out of bounds.
 fo-test-array-subarray-007,Error: FOAY0001: subarray start out of bounds.
 fo-test-array-fold-right-003,AssertionError: Expected XPath          array:fold-right([1,2,3], [], function($x, $y){[$x, $y]})        to (deep equally) resolve to [1, [2, [3, []]]]: expected false to be true
 fo-test-array-sort-002,Error: XPST0017: Function array:sort with arity of 3 not registered. Did you mean "Q{http://www.w3.org/2005/xpath-functions/array}sort (array(*))", "Q{http://www.w3.org/2001/XMLSchema}short (xs:anyAtomicType?)" or "Q{http://www.w3.org/2005/xpath-functions/math}sqrt (xs:double?)"?
-K-NumericAdd-37,AssertionError: expected [Function] to throw an error
-K-NumericAdd-39,AssertionError: Expected executing the XPath "1 + (1, 2)" to resolve to one of the expected results, but got AssertionError: expected [Function] to throw an error, AssertionError: expected [Function] to throw an error.
-K2-NumericAdd-1,AssertionError: expected [Function] to throw an error
-K2-NodeTest-37,AssertionError: expected [Function] to throw error matching /XPTY0018/ but got 'Cannot read property \'type\' of null'
-XPTY0004_46,AssertionError: expected [Function] to throw an error

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -165,18 +165,19 @@ describe('Annotate maps', () => {
 describe('annotateSimpleMapExpr', () => {
 	const context = new AnnotationContext(undefined);
 	insertVariables(context, [
-		['values', { type: ValueType.XSINTEGER, mult: SequenceMultiplicity.ZERO_OR_MORE }],
+		['numericValues', { type: ValueType.XSINTEGER, mult: SequenceMultiplicity.ZERO_OR_MORE }],
+		['stringValues', { type: ValueType.NODE, mult: SequenceMultiplicity.ZERO_OR_MORE }],
 	]);
 	it('annotate mapExpr of sequence', () =>
-		assertValueType('$values ! 4 ! 3', ValueType.XSINTEGER, context));
-	it('annotate mapExpr of sequence', () =>
-		assertValueType('$values!(.*.)', undefined, undefined));
-	it('annotate mapExpr of stringConcatenations', () =>
-		assertValueType(
-			'child::div1 / child::para / string() ! concat("id-", .)',
-			undefined,
-			undefined
-		));
+		assertValueType('$numericValues ! 4 ! 3', ValueType.XSINTEGER, context));
+	it('annotate mapExpr of sequence contextItem mult', () =>
+		assertValueType('$numericValues!(.*.)', ValueType.XSNUMERIC, undefined));
+	it('annotate mapExpr contextItem union', () =>
+		assertValueType('$stringValues!(. union //b)', ValueType.NODE, undefined));
+	it('annotate mapExpr attributes of nodes', () =>
+		assertValueType('/ ! (@first, @middle, @last)', ValueType.NODE, undefined));
+	it('annotate mapExpr of strings', () =>
+		assertValueType('(1 to 5)!"*"', ValueType.XSSTRING, undefined));
 });
 
 describe('Annotating ifThenElse expressions', () => {

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -166,14 +166,14 @@ describe('annotateSimpleMapExpr', () => {
 	const context = new AnnotationContext(undefined);
 	insertVariables(context, [
 		['numericValues', { type: ValueType.XSINTEGER, mult: SequenceMultiplicity.ZERO_OR_MORE }],
-		['stringValues', { type: ValueType.NODE, mult: SequenceMultiplicity.ZERO_OR_MORE }],
+		['nodeValues', { type: ValueType.NODE, mult: SequenceMultiplicity.ZERO_OR_MORE }],
 	]);
 	it('annotate mapExpr of sequence', () =>
 		assertValueType('$numericValues ! 4 ! 3', ValueType.XSINTEGER, context));
 	it('annotate mapExpr of sequence contextItem mult', () =>
 		assertValueType('$numericValues!(.*.)', ValueType.XSNUMERIC, undefined));
 	it('annotate mapExpr contextItem union', () =>
-		assertValueType('$stringValues!(. union //b)', ValueType.NODE, undefined));
+		assertValueType('$nodeValues!(. union //b)', ValueType.NODE, undefined));
 	it('annotate mapExpr attributes of nodes', () =>
 		assertValueType('/ ! (@first, @middle, @last)', ValueType.NODE, undefined));
 	it('annotate mapExpr of strings', () =>

--- a/test/specs/annotation.tests.ts
+++ b/test/specs/annotation.tests.ts
@@ -146,13 +146,37 @@ describe('Annotate Array', () => {
 describe('annotate Sequence', () => {
 	it('annotate simple sequence', () =>
 		assertValueType('(4, 3, hello)', ValueType.ITEM, undefined));
+	it('annotate simple sequence same type integer', () =>
+		assertValueType('(4, 3)', ValueType.XSINTEGER, undefined));
+	it('annotate simple sequence same type string', () =>
+		assertValueType('("4", "3")', ValueType.XSSTRING, undefined));
+	it('annotate complex sequence same type sequences', () =>
+		assertValueType('(("4", "he"), ("3", "hello"))', ValueType.XSSTRING, undefined));
+	it('annotate complex sequence different type sequences', () =>
+		assertValueType('(("4", "he"), ("3"))', ValueType.ITEM, undefined));
 	it('annotate complex sequence', () =>
 		assertValueType('(4, 3, hello, (43, (256, "help")))', ValueType.ITEM, undefined));
 });
 
 describe('Annotate maps', () => {
 	it('mapConstructor', () => assertValueType('map{a:1, b:2}', ValueType.MAP, undefined));
-	it('simpleMapExpr', () => assertValueType('$a ! ( //b)', undefined, undefined));
+});
+
+describe('annotateSimpleMapExpr', () => {
+	const context = new AnnotationContext(undefined);
+	insertVariables(context, [
+		['values', { type: ValueType.XSINTEGER, mult: SequenceMultiplicity.ZERO_OR_MORE }],
+	]);
+	it('annotate mapExpr of sequence', () =>
+		assertValueType('$values ! 4 ! 3', ValueType.XSINTEGER, context));
+	it('annotate mapExpr of sequence', () =>
+		assertValueType('$values!(.*.)', undefined, undefined));
+	it('annotate mapExpr of stringConcatenations', () =>
+		assertValueType(
+			'child::div1 / child::para / string() ! concat("id-", .)',
+			undefined,
+			undefined
+		));
 });
 
 describe('Annotating ifThenElse expressions', () => {


### PR DESCRIPTION
# Pull Request

## Description

This pull request adds annotation to the simpleMapExpr node, while implementing this we noticed that there is a better way to implement the annotation of the sequenceOperator. This by annotating the node if all the the types of the elements are the same.

Closes #117 

## Changes

1. Expanded on the SequenceOperatorAnnotation
2. Fixed the simpleMapExpressionAnnotation
3. Fixed the tests
4. Fixed the comments

## Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

## How Many Approvals?

* 2 Approvals (Normal features and bugs)