### PR TITLE
Remove logging of not fully annotated queries

### DIFF
--- a/src/evaluateUpdatingExpression.ts
+++ b/src/evaluateUpdatingExpression.ts
@@ -38,7 +38,6 @@ export type UpdatingOptions = {
 	disableCache?: boolean;
 	documentWriter?: IDocumentWriter;
 	logger?: Logger;
-	logUnannotatedQueries?: boolean; // TODO: Remove once node annotation is finalized.
 	moduleImports?: { [s: string]: string };
 	namespaceResolver?: (s: string) => string | null;
 	nodesFactory?: INodesFactory;
@@ -83,7 +82,6 @@ export default async function evaluateUpdatingExpression(
 				debug: !!options['debug'],
 				disableCache: !!options['disableCache'],
 				annotateAst: !!options['annotateAst'],
-				logUnannotatedQueries: !!options['logUnannotatedQueries'],
 			}
 		);
 		dynamicContext = context.dynamicContext;

--- a/src/evaluateUpdatingExpression.ts
+++ b/src/evaluateUpdatingExpression.ts
@@ -23,10 +23,7 @@ import { Language, Logger } from './types/Options';
  * debug					- Sets the debug option for the evaluation context.
  * disableCache				- Sets if the cache should or should not be disabled.
  * documentWriter			- Sets the documentwriter object
- * logger					- Sets a logger object
- * logUnannotatedQueries	- Sets if queries should be logged if they are not
- * 							  fully annotated. Mostly for testing purposes and might
- * 							  be removed if debug benefit is gone.
+ * logger					- Sets a logger object.
  * moduleImports			- Sets all the module imports.
  * namespaceResolver		- Callback to do namespace resolving.
  * nodesFactory				- Reference to a nodes factory object.

--- a/src/evaluateUpdatingExpressionSync.ts
+++ b/src/evaluateUpdatingExpressionSync.ts
@@ -55,7 +55,6 @@ export default function evaluateUpdatingExpressionSync<
 				debug: !!options['debug'],
 				disableCache: !!options['disableCache'],
 				annotateAst: !!options['annotateAst'],
-				logUnannotatedQueries: !!options['logUnannotatedQueries'],
 			}
 		);
 		dynamicContext = context.dynamicContext;

--- a/src/evaluateXPath.ts
+++ b/src/evaluateXPath.ts
@@ -156,7 +156,6 @@ const evaluateXPath = <TNode extends Node, TReturnType extends keyof IReturnType
 				debug: !!options['debug'],
 				disableCache: !!options['disableCache'],
 				annotateAst: !!options['annotateAst'],
-				logUnannotatedQueries: !!options['logUnannotatedQueries'],
 			}
 		);
 		dynamicContext = context.dynamicContext;

--- a/src/evaluationUtils/buildEvaluationContext.ts
+++ b/src/evaluationUtils/buildEvaluationContext.ts
@@ -76,7 +76,6 @@ export default function buildEvaluationContext(
 		annotateAst: boolean;
 		debug: boolean;
 		disableCache: boolean;
-		logUnannotatedQueries: boolean;
 	}
 ): {
 	dynamicContext: DynamicContext;

--- a/src/parsing/staticallyCompileXPath.ts
+++ b/src/parsing/staticallyCompileXPath.ts
@@ -22,7 +22,6 @@ export default function staticallyCompileXPath(
 		annotateAst: boolean | undefined;
 		debug: boolean | undefined;
 		disableCache: boolean | undefined;
-		logUnannotatedQueries: boolean | undefined;
 	},
 	namespaceResolver: (namespace: string) => string | null,
 	variables: { [varName: string]: any },
@@ -85,17 +84,6 @@ export default function staticallyCompileXPath(
 
 		if (compilationOptions.annotateAst) {
 			annotateAst(ast, context);
-
-			if (compilationOptions.logUnannotatedQueries) {
-				const [totalNodes, annotatedNodes] = countQueryBodyAnnotations(ast);
-
-				if (totalNodes !== annotatedNodes) {
-					// We are logging an error here so we can easily pipe the list of all failed queries into a file
-					// Example: `npm run test 2> failedQueries.txt`
-					// tslint:disable-next-line:no-console
-					console.error(xpathString);
-				}
-			}
 		}
 
 		expression = compileAstToExpression(queryBodyContents, compilationOptions);

--- a/src/typeInference/annotatePathExpr.ts
+++ b/src/typeInference/annotatePathExpr.ts
@@ -19,7 +19,7 @@ export function annotatePathExpr(ast: IAST): SequenceType {
 	let retType;
 	for (const step of steps) {
 		annotateStep(step);
-		retType = astHelper.getAttribute(step, 'type') as SequenceType;
+		retType = astHelper.getAttribute(step, 'type');
 	}
 
 	if (retType === undefined || retType === null) {
@@ -39,10 +39,7 @@ function annotateStep(step: IAST): SequenceType {
 	const lastChild = children[children.length - 1];
 	switch (lastChild[0]) {
 		case 'filterExpr': {
-			seqType = astHelper.getAttribute(
-				astHelper.followPath(lastChild, ['*']),
-				'type'
-			) as SequenceType;
+			seqType = astHelper.getAttribute(astHelper.followPath(lastChild, ['*']), 'type');
 			break;
 		}
 		case 'xpathAxis':


### PR DESCRIPTION
# Pull Request

## Description

Removes the logging of not fully annotated queries

Closes #138 

## Changes

1. Removes the compilation parameter.
2. Removes the code that relied on it.
3. Internal counting remains though, since it's low overhead and could be used again in the future.

## Deletes Source Branch?

Yes:    Work is done, the branch can be safely deleted.

## How Many Approvals?

* 2 Approvals (Normal features and bugs)